### PR TITLE
luci-proto-ppp: align keepalive defaults with current OpenWrt

### DIFF
--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_ppp.lua
@@ -103,7 +103,7 @@ function keepalive_interval.write(self, section, value)
 	if f > 0 then
 		m:set(section, "keepalive", "%d %d" %{ f, i })
 	else
-		m:del(section, "keepalive")
+		m:set(section, "keepalive", "0")
 	end
 end
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoa.lua
@@ -109,7 +109,7 @@ function keepalive_interval.write(self, section, value)
 	if f > 0 then
 		m:set(section, "keepalive", "%d %d" %{ f, i })
 	else
-		m:del(section, "keepalive")
+		m:set(section, "keepalive", "0")
 	end
 end
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppoe.lua
@@ -103,7 +103,7 @@ function keepalive_interval.write(self, section, value)
 	if f > 0 then
 		m:set(section, "keepalive", "%d %d" %{ f, i })
 	else
-		m:del(section, "keepalive")
+		m:set(section, "keepalive", "0")
 	end
 end
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppossh.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pppossh.lua
@@ -105,7 +105,7 @@ function keepalive_interval.write(self, section, value)
 	if f > 0 then
 		m:set(section, "keepalive", "%d %d" %{ f, i })
 	else
-		m:del(section, "keepalive")
+		m:set(section, "keepalive", "0")
 	end
 end
 

--- a/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua
+++ b/protocols/luci-proto-ppp/luasrc/model/cbi/admin_network/proto_pptp.lua
@@ -82,7 +82,7 @@ function keepalive_interval.write(self, section, value)
 	if f > 0 then
 		m:set(section, "keepalive", "%d %d" %{ f, i })
 	else
-		m:del(section, "keepalive")
+		m:set(section, "keepalive", "0")
 	end
 end
 


### PR DESCRIPTION
isabling LCP echos by *not* setting "option keepalive" was broken in
OpenWrt since https://dev.archive.openwrt.org/ticket/2373.html so setting
"0" in LuCI had the effect of reverting back to "5, 1" while the help
suggested otherwise.

Support for "keepalive 0" was fixed with https://git.openwrt.org/555c59230
so align LuCI now to emit "option keepalive 0" instead of removing the
option when entering "0" in the gui.