### PR TITLE
luci-app-https-dns-proxy: add DNSPod.cn and AliDNS DOH providers

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
 LUCI_PKGARCH:=all
-PKG_RELEASE:=11
+PKG_RELEASE:=12
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
@@ -1,0 +1,6 @@
+return { 
+	name="AliDNS",
+	label=_("AliDNS"),
+	resolver_url="https://dns.alidns.com/dns-query",
+	bootstrap_dns="223.5.5.5,223.6.6.6,2400:3200::1,2400:3200:baba::1"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua
@@ -1,0 +1,6 @@
+return{
+	name = "DNSPod-cn-Public-DNS",
+	label = _("DNSPod.cn Public DNS"),
+	resolver_url = "https://doh.pub/dns-query",
+	bootstrap_dns = "119.29.29.29,119.28.28.28"
+}

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -13,6 +13,10 @@ msgstr ""
 msgid "AdGuard (Standard)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua:3
+msgid "AliDNS"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua:3
 msgid "CIRA Canadian Shield (Family)"
 msgstr ""
@@ -59,6 +63,10 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3
 msgid "DNS.SB"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua:3
+msgid "DNSPod.cn Public DNS"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua:3


### PR DESCRIPTION
## 添加了DNSPod.cn和AliDNS的DOH providers

- [DNSPod.cn: https://doh.pub/dns-query](https://cloud.tencent.com/developer/article/1668074)
- [AliDNS: https://dns.alidns.com/dns-query](https://developer.aliyun.com/article/757592)