### PR TITLE
luci-app-uhttpd: Fix typo error

### DIFF
--- a/applications/luci-app-uhttpd/po/zh-cn/uhttpd.po
+++ b/applications/luci-app-uhttpd/po/zh-cn/uhttpd.po
@@ -82,7 +82,7 @@ msgid "General Settings"
 msgstr "基本设置"
 
 msgid "HTTP listeners (address:port)"
-msgstr "HTTP 监听器（address:port）"
+msgstr "HTTP 监听器（IP 地址:端口）"
 
 msgid "HTTPS Certificate (DER Encoded)"
 msgstr "HTTPS 证书（DER 编码）"
@@ -91,7 +91,7 @@ msgid "HTTPS Private Key (DER Encoded)"
 msgstr "HTTPS 私钥（DER 编码）"
 
 msgid "HTTPS listener (address:port)"
-msgstr "HTTP 监听器（address:port）"
+msgstr "HTTPS 监听器（IP 地址:端口）"
 
 msgid "Ignore private IPs on public interface"
 msgstr "忽略公共接口上的私有 IP"


### PR DESCRIPTION
修复 **HTTPS 监听器**错误地显示为 **HTTP 监听器**的问题