### PR TITLE
修复ipv6地址固定显示为[prefix]::1的问题

### DIFF
--- a/modules/luci-base/luasrc/model/network.lua
+++ b/modules/luci-base/luasrc/model/network.lua
@@ -923,7 +923,12 @@ function protocol.ip6addrs(self)
 
 	if type(addrs) == "table" then
 		for n, addr in ipairs(addrs) do
-			rv[#rv+1] = "%s1/%d" %{ addr.address, addr.mask }
+			if type(addr["local-address"]) == "table" then
+				rv[#rv+1] = "%s/%d" %{
+					addr["local-address"].address,
+					addr["local-address"].mask
+				}
+			end
 		end
 	end
 


### PR DESCRIPTION
修复问题：https://github.com/coolsnowwolf/lede/issues/6042
参考：https://github.com/openwrt/luci/commit/461df8b0dc1a9be5fb9e904d8cdc44c6d0cbd6c8