### PR TITLE
调整默认主题手机版登录页面密码框宽度比用户名窄的问题

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
@@ -85,6 +85,7 @@ header h3 a, header .brand {
 		margin-left: 0% !important;
 	}
 	.cbi-value-field input[type="text"],
+	.cbi-value-field input[type="password"],
 	.cbi-value-field select {
 		width: 100%;
 	}


### PR DESCRIPTION
默认主题的登录页在手机浏览器里访问时用户名和密码框长度不一致。

调整前：
<img width="377" alt="before" src="https://user-images.githubusercontent.com/844773/121655437-31f44600-cad1-11eb-9611-b73b66e9996e.png">

调整后：
<img width="376" alt="after" src="https://user-images.githubusercontent.com/844773/121656235-dd9d9600-cad1-11eb-9b35-32eddf7ca35c.png">


调整后对于强迫症患者更友好。
