### PR TITLE
luci-mod-admin-full: fix 'realtime wireless' no show

### DIFF
--- a/modules/luci-mod-admin-full/src/luci-bwc.c
+++ b/modules/luci-mod-admin-full/src/luci-bwc.c
@@ -42,7 +42,7 @@
 
 #define DB_PATH		"/var/lib/luci-bwc"
 #define DB_IF_FILE	DB_PATH "/if/%s"
-#define DB_RD_FILE	DB_PATH "/radio/%s"
+#define DB_RD_FILE	DB_PATH "/if/%s"
 #define DB_CN_FILE	DB_PATH "/connections"
 #define DB_LD_FILE	DB_PATH "/load"
 


### PR DESCRIPTION
bcz /var/lib/luci-bwc/radio directory doesn't exist, so change to /var/lib/luci-bwc/if

Signed-off-by: boos4721 <3.1415926535boos@gmail.com>