### PR TITLE
luci-app-dawn: add luci app for dawn

### DIFF
--- a/applications/luci-app-dawn/Makefile
+++ b/applications/luci-app-dawn/Makefile
@@ -1,0 +1,10 @@
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for DAWN
+LUCI_DEPENDS:=+dawn +luci-compat +luci-lib-json
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature
+

--- a/applications/luci-app-dawn/luasrc/controller/dawn.lua
+++ b/applications/luci-app-dawn/luasrc/controller/dawn.lua
@@ -1,0 +1,11 @@
+module("luci.controller.dawn", package.seeall)
+
+function index()
+    local e = entry({ "admin", "dawn" }, firstchild(), "DAWN", 60)
+    e.dependent = false
+    e.acl_depends = { "luci-app-dawn" }
+
+    entry({ "admin", "dawn", "configure_daemon" }, cbi("dawn/dawn_config"), "Configure DAWN", 1)
+    entry({ "admin", "dawn", "view_network" }, cbi("dawn/dawn_network"), "View Network Overview", 2)
+    entry({ "admin", "dawn", "view_hearing_map" }, cbi("dawn/dawn_hearing_map"), "View Hearing Map", 3)
+end

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_config.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_config.lua
@@ -1,0 +1,42 @@
+m = Map("dawn", translate("Dawn Configuration"), translate(""))
+s = m:section(TypedSection, "metric", "Metric", "Metric"); s.anonymous = true;
+s:option(Value, "ht_support", "High Throughput Support")
+s:option(Value, "no_ht_support", "No High Throughput Support")
+s:option(Value, "vht_support", "Very High Throughput Support")
+s:option(Value, "no_vht_support", "No Very High Throughput Support")
+s:option(Value, "rssi", "RSSI")
+s:option(Value, "low_rssi", "Low RSSI")
+s:option(Value, "freq", "5GHz")
+s:option(Value, "chan_util", "Channel Utilization")
+s:option(Value, "max_chan_util", "Above Maximum Channel Utilization")
+
+s = m:section(TypedSection, "metric", "Threshold", "Thresholds"); s.anonymous = true;
+s:option(Value, "bandwidth_threshold", "Bandwidth Threshold")
+s:option(Value, "rssi_val", "RSSI Threshold")
+s:option(Value, "low_rssi_val", "Low RSSI Threshold")
+s:option(Value, "chan_util_val", "Channel Utilization Threshold")
+s:option(Value, "max_chan_util_val", "Maximaum Channel Utilization Threshold")
+s:option(Value, "min_probe_count", "Minimum Probe Count")
+s:option(Value, "min_number_to_kick", "Minimum Number After Kicking Client")
+
+s = m:section(TypedSection, "metric", "Evaluate", "What should be evaluated?"); s.anonymous = true;
+s:option(Flag, "kicking", "Activate Kicking")
+s:option(Flag, "eval_probe_req", "Evaluate Probe Requests")
+s:option(Flag, "eval_auth_req", "Evaluate Authentication Requests")
+s:option(Flag, "eval_assoc_req", "Evaluate Association Requests")
+s:option(Flag, "use_station_count", "Use Station Count")
+
+s = m:section(TypedSection, "metric", "IEE802.11", "Reasons for denying"); s.anonymous = true;
+s:option(Value, "deny_auth_reason", "Denying Authentication")
+s:option(Value, "deny_assoc_reason", "Denying Association")
+
+s = m:section(TypedSection, "times", "Time Configuration", "Time Configs"); s.anonymous = true;
+s:option(Value, "update_client", "Update Client Information Interval")
+s:option(Value, "denied_req_threshold", "Checking if client is connected")
+s:option(Value, "remove_client", "Remove Client Information")
+s:option(Value, "remove_probe", "Remove Hearing Map Information")
+s:option(Value, "update_hostapd", "Check for new Hostapd Sockets")
+s:option(Value, "update_tcp_con", "Check for new Routers")
+s:option(Value, "update_chan_util", "Update Channel Utilization Interval")
+
+return m

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -1,0 +1,68 @@
+m = Map("dawn", "Hearing Map", translate("Hearing Map"))
+m.pageaction = false
+
+s = m:section(NamedSection, "__hearingmap__")
+
+function s.render(self, sid)
+	local tpl = require "luci.template"
+	tpl.render_string([[
+		<%
+			local utl = require "luci.util"
+			local xml = require "luci.xml"
+			local status = require "luci.tools.ieee80211"
+			local stat = utl.ubus("dawn", "get_hearing_map", { })
+			local name, macs
+
+			for name, macs in pairs(stat) do
+		%>
+			<div class="cbi-section-node">
+				<h3>SSID: <%= xml.pcdata(name) %></h3>
+				<table class="table" id="dawn_hearing_map">
+					<tr class="tr table-titles">
+						<th class="th">Client MAC</th>
+						<th class="th">AP MAC</th>
+						<th class="th">Frequency</th>
+						<th class="th">HT Sup</th>
+						<th class="th">VHT Sup</th>
+						<th class="th">Signal</th>
+						<th class="th">RCPI</th>
+						<th class="th">RSNI</th>
+						<th class="th">Channel Utilization</th>
+						<th class="th">Station connect to AP</th>
+						<th class="th">Score</th>
+					</tr>
+					<%
+						local mac, data
+						for mac, data in pairs(macs) do
+
+							local mac2, data2
+							local count_loop = 0
+							for mac2, data2 in pairs(data) do
+					%>
+						<tr class="tr">
+							<td class="td"><%= (count_loop == 0) and mac or "" %></td>
+							<td class="td"><%= mac2 %></td>
+							<td class="td"><%= "%.3f" %( data2.freq / 1000 ) %> GHz Channel: <%= "%d" %( status.frequency_to_channel(data2.freq) ) %></td>
+							<td class="td"><%= (data2.ht_capabilities == true and data2.ht_support == true) and "True" or "False" %></td>
+							<td class="td"><%= (data2.vht_capabilities == true and data2.vht_support == true) and "True" or "False" %></td>
+							<td class="td"><%= "%d" % data2.signal %></td>
+							<td class="td"><%= "%d" % data2.rcpi %></td>
+							<td class="td"><%= "%d" % data2.rsni %></td>
+							<td class="td"><%= "%.2f" % (data2.channel_utilization / 2.55) %> %</td>
+							<td class="td"><%= "%d" % data2.num_sta %></td>
+							<td class="td"><%= "%d" % data2.score %></td>
+						</tr>
+					<%
+								count_loop = count_loop + 1
+							end
+						end
+					%>
+				</table>
+			</div>
+		<%
+			end
+		%>
+	]])
+end
+
+return m

--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_network.lua
@@ -1,0 +1,94 @@
+m = Map("dawn", "Network Overview", translate("Network Overview"))
+m.pageaction = false
+
+s = m:section(NamedSection, "__networkoverview__")
+
+function s.render(self, sid)
+	local tpl = require "luci.template"
+	local json = require "luci.json"
+	local utl = require "luci.util"
+	tpl.render_string([[
+		<%
+			local status = require "luci.tools.ieee80211"
+			local utl = require "luci.util"
+			local sys = require "luci.sys"
+			local xml = require "luci.xml"
+			local hosts = sys.net.host_hints()
+			local stat = utl.ubus("dawn", "get_network", { })
+			local name, macs
+			for name, macs in pairs(stat) do
+		%>
+			<div class="cbi-section-node">
+				<h3>SSID: <%= xml.pcdata(name) %></h3>
+				<table class="table" id="network_overview_main">
+					<tr class="tr table-titles">
+						<th class="th">AP</th>
+						<th class="th">Clients</th>
+					</tr>
+					<%
+						local mac, data
+						for mac, data in pairs(macs) do
+					%>
+						<tr class="tr">
+							<td class="td" style="vertical-align: top;">
+								<table class="table" id="ap-<%= mac %>">
+									<tr class="tr table-titles">
+										<th class="th">Hostname</th>
+										<th class="th">Interface</th>
+										<th class="th">MAC</th>
+										<th class="th">Utilization</th>
+										<th class="th">Frequency</th>
+										<th class="th">Stations</th>
+										<th class="th">HT Sup</th>
+										<th class="th">VHT Sup</th>
+									</tr>
+									<tr class="tr">
+										<td class="td"><%= xml.pcdata(data.hostname) %></td>
+										<td class="td"><%= xml.pcdata(data.iface) %></td>
+										<td class="td"><%= mac %></td>
+										<td class="td"><%= "%.2f" %(data.channel_utilization / 2.55) %> %</td>
+										<td class="td"><%= "%.3f" %( data.freq / 1000 ) %> GHz (Channel: <%= "%d" %( status.frequency_to_channel(data.freq) ) %>)</td>
+										<td class="td"><%= "%d" % data.num_sta %></td>
+										<td class="td"><%= (data.ht_support == true) and "available" or "not available" %></td>
+										<td class="td"><%= (data.vht_support == true) and "available" or "not available" %></td>
+									</tr>
+								</table>
+							</td>
+							<td class="td" style="vertical-align: top;">
+								<table class="table" id="clients-<%= mac %>">
+									<tr class="tr table-titles">
+										<th class="th">MAC</th>
+										<th class="th">HT</th>
+										<th class="th">VHT</th>
+										<th class="th">Signal</th>
+									</tr>
+									<%
+										local mac2, data2
+										for clientmac, clientvals in pairs(data) do
+											if (type(clientvals) == "table") then
+									%>
+										<tr class="tr">
+											<td class="td"><%= clientmac %></td>
+											<td class="td"><%= (clientvals.ht == true) and "available" or "not available" %></td>
+											<td class="td"><%= (clientvals.vht == true) and "available" or "not available" %></td>
+											<td class="td"><%= "%d" % clientvals.signal %></td>
+										</tr>
+									<%
+											end
+										end
+									%>
+								</table>
+							</td>
+						</tr>
+					<%
+						end
+					%>
+				</table>
+			</div>
+		<%
+			end
+		%>
+	]])
+end
+
+return m

--- a/applications/luci-app-dawn/luasrc/tools/ieee80211.lua
+++ b/applications/luci-app-dawn/luasrc/tools/ieee80211.lua
@@ -1,0 +1,18 @@
+module("luci.tools.ieee80211", package.seeall)
+
+function frequency_to_channel(freq)
+	if (freq == 2484) then
+		return 14;
+	elseif (freq < 2484) then
+		return (freq - 2407) / 5;
+	elseif (freq >= 4910 and freq <= 4980) then
+		return (freq - 4000) / 5;
+	elseif (freq <= 45000) then
+		return (freq - 5000) / 5;
+	elseif (freq >= 58320 and freq <= 64800) then
+		return (freq - 56160) / 2160;
+	else
+		return 0;
+	end
+end
+

--- a/applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json
+++ b/applications/luci-app-dawn/root/usr/share/rpcd/acl.d/luci-app-dawn.json
@@ -1,0 +1,11 @@
+{
+	"luci-app-dawn": {
+		"description": "Grant UCI access for luci-app-dawn",
+		"read": {
+			"uci": [ "dawn" ]
+		},
+		"write": {
+			"uci": [ "dawn" ]
+		}
+	}
+}


### PR DESCRIPTION
Dawn is a decentralized WiFi controller.
Just install dawn and the APs will find each other via umdns. They
periodically exchange information about connected clients, wireless
statistics and other needed information. With that, the daemon load
balances clients between different APs through association control.

Luci-app-dawn is the graphical user interface.
It allows to:
- Configure dawn
- View Wireless Network Overview
- View Hearing Map

The hearing map is the list of all probe requests seen from a client
from all APs that are running the controller.