### PR TITLE
luci-app-adblock: fix; fixes coolsnowwolf/lede#7358

### DIFF
--- a/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
+++ b/applications/luci-app-adblock/luasrc/model/cbi/adblock/overview_tab.lua
@@ -27,12 +27,12 @@ s = m:section(NamedSection, "global", "adblock")
 
 local parse = json.parse(fs.readfile(adbinput) or "")
 if parse then
-	status  = parse.data.adblock_status
-	version = parse.data.adblock_version
-	domains = parse.data.overall_domains
-	fetch   = parse.data.fetch_utility
-	backend = parse.data.dns_backend
-	rundate = parse.data.last_rundate
+	status  = parse.adblock_status
+	version = parse.adblock_version
+	domains = parse.overall_domains
+	fetch   = parse.fetch_utility
+	backend = parse.dns_backend
+	rundate = parse.last_rundate
 end
 
 o1 = s:option(Flag, "adb_enabled", translate("Enable Adblock"))


### PR DESCRIPTION
The data to extract from `local parse = json.parse(fs.readfile(adbinput) or "")` is now in `parse` self, not in `parse.data`.
`parse` is a table that looks like this:

```
{["adblock_status"]="enabled",["run_directories"]="base: /tmp, backup: /tmp/adblock-Backup,
report: /tmp/adblock-Report, jail: /tmp",["run_utils"]="download: /bin/uclient-fetch,
sort: /usr/libexec/sort-coreutils, awk: /bin/busybox",["system"]="Xiaomi AX3600, OpenWrt ",
["blocked_domains"]="44005",["last_run"]="start, 0m 6s, 417/233/231, 01.10.2021 15:26:07",
["adblock_version"]="4.1.3", ["active_sources"]={{["source"]="adaway"},{["source"]="adguard"},
{["source"]="disconnect"}, {["source"]="yoyo"}},["dns_backend"]="dnsmasq (-), /tmp/dnsmasq.d",
["run_flags"]="backup: ✔, flush: ✘, force: ✘, search: ✘, report: ✘, mail: ✘, jail: ✘",
["run_ifaces"]="trigger: lan, report: -"}
```