### PR TITLE
luci-base: redirect / to /cgi-bin/luci/ to avoid login

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -102,6 +102,11 @@ end
 function httpdispatch(request, prefix)
 	http.context.request = request
 
+	if luci.http.getenv("REQUEST_URI") == "/" then
+		luci.http.redirect('/cgi-bin/luci/')
+		return
+	end
+
 	local r = {}
 	context.request = r
 


### PR DESCRIPTION
登录相关cookie种在 `/cgi-bin/luci` 路径
在浏览器直接输入`openwrt.lan`进行2次登录，不带完整路径，会被要求重新输入用户名和密码