### PR TITLE
Crontab: Avoid some formatting issues

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/crontab.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/crontab.lua
@@ -4,6 +4,7 @@
 
 local fs = require "nixio.fs"
 local cronfile = "/etc/crontabs/root" 
+local util = require "luci.util"
 
 f = SimpleForm("crontab", translate("Scheduled Tasks"),
 	translate("This is the system crontab in which scheduled tasks can be defined.") ..
@@ -20,7 +21,7 @@ end
 function f.handle(self, state, data)
 	if state == FORM_VALID then
 		if data.crons then
-			fs.writefile(cronfile, data.crons:gsub("\r\n", "\n"))
+			fs.writefile(cronfile, util.trim(data.crons):gsub("\r\n", "\n") .. "\n")
 			luci.sys.call("/usr/bin/crontab %q" % cronfile)
 		else
 			fs.writefile(cronfile, "")


### PR DESCRIPTION
See issue:    coolsnowwolf/lede#6544
Refer to Upstream: [contrab.js](https://github.com/openwrt/luci/blob/master/modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js)