### PR TITLE
加强版dnsmasq补丁支持过滤type65 https和unknown类型dns请求

### DIFF
--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -260,6 +260,18 @@ msgstr "禁止解析 IPv6 DNS 记录"
 msgid "Filter IPv6(AAAA) DNS Query Name Resolve"
 msgstr "过滤掉 IPv6(AAAA) ，只返回 IPv4 DNS 域名记录"
 
+msgid "Disable HTTPS DNS Type forwards"
+msgstr "禁止解析 HTTPS 类型的记录"
+
+msgid "Filter HTTPS DNS Query Type Name Resolve"
+msgstr "过滤掉 HTTPS 类型65的查询 ，避免iOS设备绕过常规DNS服务"
+
+msgid "Disable Unknown DNS Type forwards"
+msgstr "禁止解析 Unknown 类型的记录"
+
+msgid "Filter Unknown DNS Query Type Name Resolve"
+msgstr "过滤掉 Unknown 未知类型的查询"
+
 msgid "Minimum TTL to send to clients"
 msgstr "客户端缓存的最小 DNS TTL"
 

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -63,6 +63,16 @@ aaaa = s:taboption("advanced", Flag, "filter_aaaa",
 	translate("Filter IPv6(AAAA) DNS Query Name Resolve"))
 aaaa.optional = true
 
+https = s:taboption("advanced", Flag, "filter_https",
+	translate("Disable HTTPS DNS Type forwards"),
+	translate("Filter HTTPS DNS Query Type Name Resolve"))
+https.optional = true
+
+unknown = s:taboption("advanced", Flag, "filter_unknown",
+	translate("Disable Unknown DNS Type forwards"),
+	translate("Filter Unknown DNS Query Type Name Resolve"))
+unknown.optional = true
+
 qu = s:taboption("advanced", Flag, "quietdhcp",
 	translate("Suppress logging"),
 	translate("Suppress logging of the routine operation of these protocols"))


### PR DESCRIPTION
这是luci支持部分，related to coolsnowwolf/lede#8909