### PR TITLE
添加lz4hc和zstd的zram选项

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
@@ -121,6 +121,8 @@ if has_zram then
 	o.placeholder = lzo
 	o:value("lzo", "lzo")
 	o:value("lz4", "lz4")
+	o:value("lz4hc", "lz4hc")
+	o:value("zstd", "zstd")
 	o:value("deflate", "deflate")
 	
 	o = s:taboption("zram", Value, "zram_comp_streams", translate("ZRam Compression Streams"), translate("Number of parallel threads used for compression"))


### PR DESCRIPTION
zram-swap包可选zstd为默认压缩算法,但界面没有显示,然后看内核日志还是以界面的为准了