### PR TITLE
Fixed the problem that the verysync service failed to start。

### DIFF
--- a/applications/luci-app-verysync/root/etc/init.d/verysync
+++ b/applications/luci-app-verysync/root/etc/init.d/verysync
@@ -3,6 +3,8 @@
 START=50
 STOP=10
 
+VERYSYNC="/usr/bin/verysync"
+
 start() {
 	local enabled="$(uci get verysync.config.enabled)"
 	local port="$(uci get verysync.config.port)"
@@ -10,9 +12,9 @@ start() {
 	stop
 	[ "${enabled}" == "1" ] || exit 0
 	export HOME="/root/"
-	verysync -gui-address="0.0.0.0:${port}" -logfile="/var/log/verysync.log" -home="${profile}" -no-browser >/dev/null 2>&1 &
+	"${VERYSYNC}" -gui-address="0.0.0.0:${port}" -logfile="/var/log/verysync.log" -home="${profile}" -no-browser >/dev/null 2>&1 &
 }
 
 stop() {
-	kill -9 `pgrep verysync` >/dev/null 2>&1
+	kill -9 `pgrep "${VERYSYNC}"` >/dev/null 2>&1
 }


### PR DESCRIPTION
Fixed the problem that the service failed to start。

The problem is: 
~# service verysync start
Killed
~#