### PR TITLE
N2N服务器端dhcp设置

### DIFF
--- a/applications/luci-app-n2n_v2/Makefile
+++ b/applications/luci-app-n2n_v2/Makefile
@@ -11,7 +11,7 @@ LUCI_DEPENDS:=+n2n-edge +n2n-supernode
 LUCI_PKGARCH:=all
 
 PKG_NAME:=luci-app-n2n_v2
-PKG_VERSION:=2.8.1
+PKG_VERSION:=3.0.0
 PKG_RELEASE:=3
 
 include ../../luci.mk

--- a/applications/luci-app-n2n_v2/luasrc/model/cbi/n2n_v2.lua
+++ b/applications/luci-app-n2n_v2/luasrc/model/cbi/n2n_v2.lua
@@ -94,6 +94,9 @@ port = s:option(Value, "port", translate("Port"))
 port.datatype = "port"
 port.optional = false
 
+subnet = s:option(Value, "subnet", translate("DHCP Subnet"))
+subnet.optional = false
+
 -- Static route
 s = m:section(TypedSection, "route", translate("N2N routes"),
               translate("Static route for n2n interface"))

--- a/applications/luci-app-n2n_v2/po/zh-cn/n2n_v2.po
+++ b/applications/luci-app-n2n_v2/po/zh-cn/n2n_v2.po
@@ -50,6 +50,9 @@ msgstr "N2N Supernode节点设置"
 msgid "Port"
 msgstr "端口"
 
+msgid "DHCP Subnet"
+msgstr "子网IP段"
+
 msgid "Supernode Port"
 msgstr "Supernode节点端口"
 


### PR DESCRIPTION
supernode参数用于客户端在dhcp模式下自动分配IP，便于使用
-a IP段 | 用于自动分配IP，格式如 -a 192.168.0.0-192.168.255.0/24
n2n_v2中也已同步更新