### PR TITLE
Update turboacc

### DIFF
--- a/applications/luci-app-turboacc/root/etc/init.d/turboacc
+++ b/applications/luci-app-turboacc/root/etc/init.d/turboacc
@@ -294,8 +294,9 @@ stop(){
 		/etc/init.d/shortcut-fe stop 2>"/dev/null"
 	}
 
+        revert_dns
 	stop_dnscache
-	revert_dns
+	
 
 	if [ "${restart_utils}" = "true" ]; then
 		echo "DNSMASQ revert"


### PR DESCRIPTION
修正turboacc关闭dnscache时dnsmasq不能还原问题