### PR TITLE
luci-app-turboacc: fix hw_flow always true when mtkhnat.ko present

### DIFF
--- a/applications/luci-app-turboacc/root/etc/init.d/turboacc
+++ b/applications/luci-app-turboacc/root/etc/init.d/turboacc
@@ -21,7 +21,7 @@ inital_conf(){
 	config_get "dns_caching_mode" "config" "dns_caching_mode" "0"
 	config_get "dns_caching_dns" "config" "dns_caching_dns"
 
-	[ -e "/lib/modules/$(uname -r)/mtkhnat.ko" ] && { sw_flow="0"; hw_flow="1"; }
+	[ ! -e "/lib/modules/$(uname -r)/mtkhnat.ko" ] && hw_flow="0";
 	[ ! -e "/lib/modules/$(uname -r)/xt_FLOWOFFLOAD.ko" ] && { sw_flow="0"; hw_flow="0"; }
 	[ ! -e "/lib/modules/$(uname -r)/tcp_bbr.ko" ] && bbr_cca="0"
 }


### PR DESCRIPTION
We may need to disable MTK HWNAT in some cases, however, ```start()``` calls ```initial_conf()``` where ```$hw_flow``` is always set true when mtkhnat.ko is present. Therefore ```rmmod mtkhnat``` in ```stop()``` makes no sense because when ```start``` is called mtkhnat.ko will always be loaded.

PS:
May be inital_conf should be renamed intial_conf?

PS:
In line 3 of turboacc_status.htm, ```/etc/init.d/turboacc check_status fastpath``` may return empty value when xhr is requsted just after stop() finishes, causing empty response.
It's not a big problem and I'm sorry that I can't find a way to fix that.

```
	XHR.poll(5, '<%=luci.dispatcher.build_url("admin", "network", "turboacc", "status")%>', null, function(x, status) {
		if ( x && x.status == 200 ) {
			fastpath_state.innerHTML = status.fastpath_state ? '<em><b><font color=green><%=luci.sys.exec("/etc/init.d/turboacc check_status fastpath")%></font></b></em>' : '<em><b><font color=red><%:NOT RUNNING%></font></b></em>';
			fullconenat_state.innerHTML = status.fullconenat_state ? '<em><b><font color=green><%:RUNNING%></font></b></em>' : '<em><b><font color=red><%:NOT RUNNING%></font></b></em>';
			bbr_state.innerHTML = status.bbr_state ? '<em><b><font color=green><%:RUNNING%></font></b></em>' : '<em><b><font color=red><%:NOT RUNNING%></font></b></em>';
			dnscaching_state.innerHTML = status.dnscaching_state ? '<em><b><font color=green><%:RUNNING%></font></b></em>' : '<em><b><font color=red><%:NOT RUNNING%></font></b></em>';
		}
	});
```
Applying:
![W(K3GJ21BT)RP% Z0OY)61S](https://user-images.githubusercontent.com/22554102/203319547-dac691db-1224-4833-8960-fe503875dc7c.png)
After:
![`E5)NE{ZKZ_1C%_A$TBH7JT](https://user-images.githubusercontent.com/22554102/203319567-174d516e-8dc4-467c-b52a-24ca6607802c.png)


After all, apreciate for porting MTK HWNAT anyway. : )