### PR TITLE
update init config

### DIFF
--- a/applications/luci-app-haproxy-tcp/root/etc/haproxy_init.sh
+++ b/applications/luci-app-haproxy-tcp/root/etc/haproxy_init.sh
@@ -24,8 +24,8 @@ start(){
   daemon		                #以后台形式运行harpoxy
   #nbproc 1                         #设置进程数量
   pidfile /var/run/haproxy.pid
-  ulimit-n 1024                    #ulimit 的数量限制
-  maxconn 2048	                #默认最大连接数,需考虑ulimit-n限制
+  #ulimit-n 1024                    #ulimit 的数量限制
+  #maxconn 2048	                #默认最大连接数,需考虑ulimit-n限制
   #chroot /usr/local/haproxy
 defaults
   log global


### PR DESCRIPTION
Haproxy still did not work after haproxy-tcp upgarde to v2.6.6.
 `[haproxy.main()] FD limit (1024) too low for maxconn=2048/maxsock=4123. Please raise 'ulimit-n' to 4123 or more to avoid any trouble.`
 Need to comment the `ulimit-n` and `maxconn`.