### PR TITLE
Revert "luci-base: support dnsmasq-filter-a (#167)"

### DIFF
--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -257,14 +257,20 @@ msgstr "额外的 HOSTS 文件"
 msgid "Disable IPv6 DNS forwards"
 msgstr "禁止解析 IPv6 DNS 记录"
 
-msgid "Disable IPv4 DNS forwards"
-msgstr "禁止解析 IPv4 DNS 记录"
-
 msgid "Filter IPv6(AAAA) DNS Query Name Resolve"
 msgstr "过滤掉 IPv6(AAAA) ，只返回 IPv4 DNS 域名记录"
 
-msgid "Filter IPv4(A) DNS Query Name Resolve"
-msgstr "过滤掉 IPv4(A) ，只返回 IPv6 DNS 域名记录"
+msgid "Disable HTTPS DNS Type forwards"
+msgstr "禁止解析 HTTPS 类型的记录"
+
+msgid "Filter HTTPS DNS Query Type Name Resolve"
+msgstr "过滤掉 HTTPS 类型65的查询 ，避免iOS设备绕过常规DNS服务"
+
+msgid "Disable Unknown DNS Type forwards"
+msgstr "禁止解析 Unknown 类型的记录"
+
+msgid "Filter Unknown DNS Query Type Name Resolve"
+msgstr "过滤掉 Unknown 未知类型的查询"
 
 msgid "Minimum TTL to send to clients"
 msgstr "客户端缓存的最小 DNS TTL"

--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_network/dhcp.lua
@@ -63,10 +63,15 @@ aaaa = s:taboption("advanced", Flag, "filter_aaaa",
 	translate("Filter IPv6(AAAA) DNS Query Name Resolve"))
 aaaa.optional = true
 
-a = s:taboption("advanced", Flag, "filter_a",
-	translate("Disable IPv4 DNS forwards"),
-	translate("Filter IPv4(A) DNS Query Name Resolve"))
-a.optional = true
+https = s:taboption("advanced", Flag, "filter_https",
+	translate("Disable HTTPS DNS Type forwards"),
+	translate("Filter HTTPS DNS Query Type Name Resolve"))
+https.optional = true
+
+unknown = s:taboption("advanced", Flag, "filter_unknown",
+	translate("Disable Unknown DNS Type forwards"),
+	translate("Filter Unknown DNS Query Type Name Resolve"))
+unknown.optional = true
 
 qu = s:taboption("advanced", Flag, "quietdhcp",
 	translate("Suppress logging"),


### PR DESCRIPTION
This reverts commit afbe07de4ebf0b7f9f507dc947e8cf102266bf86.

Because of revert of "dnsmasq: bump to v2.87", revert this commit as well.