### PR TITLE
luci-app-unblockmusic: add white mode & fix cloud mode ssl cert error on other website

### DIFF
--- a/applications/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic/unblockmusic.lua
+++ b/applications/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic/unblockmusic.lua
@@ -92,6 +92,11 @@ restart.write = function()
 end
 restart:depends("apptype", "nodejs")
 
+acl_mode = s:option(ListValue, "acl_mode", translate("默认解锁模式"))
+acl_mode:value(0, translate("解锁"))
+acl_mode:value(1, translate("不解锁"))
+acl_mode.default = 0
+
 t = mp:section(TypedSection, "acl_rule")
 t.title = translate("例外客户端规则")
 t.description = translate("可以为局域网客户端分别设置不同的例外模式，默认无需设置")
@@ -117,5 +122,7 @@ filter_mode.rmempty = false
 filter_mode:value("disable", translate("不代理HTTP和HTTPS"))
 filter_mode:value("http", translate("不代理HTTP"))
 filter_mode:value("https", translate("不代理HTTPS"))
+filter_mode:value("proxy_http", translate("代理HTTP"))
+filter_mode:value("proxy_http_https", translate("代理HTTP和HTTPS"))
 
 return mp

--- a/applications/luci-app-unblockmusic/root/etc/init.d/unblockmusic
+++ b/applications/luci-app-unblockmusic/root/etc/init.d/unblockmusic
@@ -1,66 +1,70 @@
 #!/bin/sh /etc/rc.common
 
-. /lib/functions/network.sh
-
 START=97
 STOP=10
 
 NAME=unblockmusic
 
 uci_get_by_type() {
-	local ret=$(uci get $NAME.@$1[0].$2 2>/dev/null)
-	echo ${ret:=$3}
+    local ret=$(uci get $NAME.@$1[0].$2 2>/dev/null)
+    echo ${ret:=$3}
 }
 
 uci_get_by_name() {
-	local index=0
-	if [ -n $4 ]; then
-	
-		index=$4
-	fi
-	local ret=$(uci get $NAME.@$1[$index].$2 2>/dev/null)
-	echo ${ret:=$3}
+    local index=0
+    if [ -n $4 ]; then
+
+        index=$4
+    fi
+    local ret=$(uci get $NAME.@$1[$index].$2 2>/dev/null)
+    echo ${ret:=$3}
 }
 
 check_host() {
-  local host=$1
-  if echo $host | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
-		hostip=$host
-	elif [ "$host" != "${host#*:[0-9a-fA-F]}" ]; then
-		hostip=$host
-	else
-		hostip=$(ping $host -W 1 -s 1 -c 1 | grep PING | cut -d'(' -f 2 | cut -d')' -f1)
-		if echo $hostip | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
-			hostip=$hostip
-		else
-			hostip="127.0.0.1"
-		fi
-	fi
-	echo -e $hostip
+    local host=$1
+    if echo $host | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
+        hostip=$host
+    elif [ "$host" != "${host#*:[0-9a-fA-F]}" ]; then
+        hostip=$host
+    else
+        hostip=$(ping $host -W 1 -s 1 -c 1 | grep PING | cut -d'(' -f 2 | cut -d')' -f1)
+        if echo $hostip | grep -E "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$" >/dev/null; then
+            hostip=$hostip
+        else
+            hostip="127.0.0.1"
+        fi
+    fi
+    echo -e $hostip
 }
 
 ip_rule()
 {
-  local icount=$(uci show unblockmusic | grep 'filter_mode' | wc -l)
-  let icount=icount-1
+    local icount=$(uci show unblockmusic | grep 'filter_mode' | wc -l)
+    let icount=icount-1
 	for i in $(seq 0 $icount)
 	do
-		local ip=$(uci_get_by_name acl_rule ipaddr '' $i)
-		local mode=$(uci_get_by_name acl_rule filter_mode '' $i)
+        local ip=$(uci_get_by_name acl_rule ipaddr '' $i)
+        local mode=$(uci_get_by_name acl_rule filter_mode '' $i)
 
-		case "$mode" in
-		http)
-			ipset -! add music_http $ip
-			;;
-		https)
-			ipset -! add music_https $ip
-			;;
-		disable)
-			ipset -! add music_http $ip
-			ipset -! add music_https $ip
-			;;
-		esac
-	done
+        case "$mode" in
+        http)
+            ipset -! add music_http $ip
+            ;;
+        https)
+            ipset -! add music_https $ip
+            ;;
+        disable)
+            ipset -! add music_http $ip
+            ipset -! add music_https $ip
+            ;;
+        proxy_http)
+            ipset -! add music_proxy_http $ip
+            ;;
+        proxy_http_https)
+            ipset -! add music_proxy_http $ip
+            ipset -! add music_proxy_https $ip
+        esac
+    done
 }
 
 ENABLE=$(uci_get_by_type unblockmusic enabled 0)
@@ -71,6 +75,7 @@ SEARCHLIMIT=$(uci_get_by_type unblockmusic search_limit 0)
 FLAC=$(uci_get_by_type unblockmusic flac_enabled 0)
 REPLACE_MUSIC_SOURCE=$(uci_get_by_type unblockmusic replace_music_source 0)
 LOCAL_VIP=$(uci_get_by_type unblockmusic local_vip 0)
+ACLMODE=$(uci_get_by_type unblockmusic acl_mode 0)
 
 CLOUD=$(uci_get_by_type unblockmusic cloudserver "127.0.0.1:5200:5201")
 cloudadd=$(echo "$CLOUD" | awk -F ':' '{print $1}')
@@ -79,59 +84,92 @@ cloudhttps=$(echo "$CLOUD" | awk -F ':' '{print $3}')
 
 cloudip=$(check_host $cloudadd)
 
-network_flush_cache
-network_get_ipaddr lanaddr "lan"
-
 CRON_FILE=/etc/crontabs/root
 
 ipt_n="iptables -t nat"
 
 add_rule()
 {
-  ipset -! -N music hash:ip
-  ipset -! -N music_http hash:ip
-  ipset -! -N music_https hash:ip
-	$ipt_n -N CLOUD_MUSIC
-	$ipt_n -A CLOUD_MUSIC -d 0.0.0.0/8 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 10.0.0.0/8 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 127.0.0.0/8 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 169.254.0.0/16 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 172.16.0.0/12 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 192.168.0.0/16 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 224.0.0.0/4 -j RETURN
-	$ipt_n -A CLOUD_MUSIC -d 240.0.0.0/4 -j RETURN
-	if [ "$APPTYPE" != "cloud" ]; then
-    $ipt_n -A CLOUD_MUSIC -p tcp -m set ! --match-set music_http src --dport 80 -j REDIRECT --to-ports 5200
-    $ipt_n -A CLOUD_MUSIC -p tcp -m set ! --match-set music_https src --dport 443 -j REDIRECT --to-ports 5201
-  else
-    $ipt_n -A CLOUD_MUSIC -p tcp -m set ! --match-set music_http src --dport 80 -j DNAT --to $cloudip:$cloudhttp
-    $ipt_n -A CLOUD_MUSIC -p tcp -m set ! --match-set music_https src --dport 443 -j DNAT --to $cloudip:$cloudhttps
-    $ipt_n -I POSTROUTING -p tcp -m multiport --dport $cloudhttp,$cloudhttps -d $cloudip -j SNAT --to-source $lanaddr
-	fi
-	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j CLOUD_MUSIC
-	iptables -I OUTPUT -d 223.252.199.10 -j DROP
-	
-	ip_rule
+    ipset -! -N music hash:ip
+    ipset -! -N music_http hash:ip
+    ipset -! -N music_https hash:ip
+    ipset -! -N music_proxy_http hash:ip
+    ipset -! -N music_proxy_https hash:ip
+    $ipt_n -N CLOUD_MUSIC
+    $ipt_n -A CLOUD_MUSIC -d 0.0.0.0/8 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 10.0.0.0/8 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 127.0.0.0/8 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 169.254.0.0/16 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 172.16.0.0/12 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 192.168.0.0/16 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 224.0.0.0/4 -j RETURN
+    $ipt_n -A CLOUD_MUSIC -d 240.0.0.0/4 -j RETURN
+    if [ "$APPTYPE" != "cloud" ]; then
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_http src --dport 80 -j RETURN
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_https src --dport 443 -j RETURN
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_proxy_http src --dport 80 -j REDIRECT --to-ports 5200
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_proxy_https src --dport 443 -j REDIRECT --to-ports 5201
+
+        if [ "$ACLMODE" == "0" ]; then
+            $ipt_n -A CLOUD_MUSIC -p tcp --dport 80 -j REDIRECT --to-ports 5200
+            $ipt_n -A CLOUD_MUSIC -p tcp --dport 443 -j REDIRECT --to-ports 5201
+        fi
+    else
+        local lan_addr
+
+        . /lib/functions/network.sh
+
+        network_flush_cache
+        network_get_ipaddr lanaddr "lan"
+
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_http src --dport 80 -j RETURN
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_https src --dport 443 -j RETURN
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_proxy_http src --dport 80 -j DNAT --to $cloudip:$cloudhttp
+        $ipt_n -A CLOUD_MUSIC -p tcp -m set --match-set music_proxy_https src --dport 443 -j DNAT --to $cloudip:$cloudhttps
+
+        if [ "$ACLMODE" == "0" ]; then
+            $ipt_n -A CLOUD_MUSIC -p tcp --dport 80 -j DNAT --to $cloudip:$cloudhttp
+            $ipt_n -A CLOUD_MUSIC -p tcp --dport 443 -j DNAT --to $cloudip:$cloudhttps
+        fi
+
+        $ipt_n -I POSTROUTING -p tcp -m multiport --dport $cloudhttp,$cloudhttps -d $cloudip -j SNAT --to-source $lanaddr
+    fi
+    
+    $ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j CLOUD_MUSIC
+    iptables -I OUTPUT -d 223.252.199.10 -j DROP
+
+    ip_rule
 }
 
 del_rule(){
-	$ipt_n -D PREROUTING -p tcp -m set --match-set music dst -j CLOUD_MUSIC 2>/dev/null
+    $ipt_n -D PREROUTING -p tcp -m set --match-set music dst -j CLOUD_MUSIC 2>/dev/null
+
+    if [ "$APPTYPE" == "cloud" ]; then
+        local lan_addr
+
+        . /lib/functions/network.sh
+
+        network_flush_cache
+        network_get_ipaddr lanaddr "lan"
         $ipt_n -D POSTROUTING -p tcp -m multiport --dport $cloudhttp,$cloudhttps -d $cloudip -j SNAT --to-source $lanaddr 2>/dev/null
-	$ipt_n -F CLOUD_MUSIC  2>/dev/null
-	$ipt_n -X CLOUD_MUSIC  2>/dev/null
-	iptables -D OUTPUT -d 223.252.199.10 -j DROP 2>/dev/null
-	
-	ipset flush music 2>/dev/null
-	ipset -X music_http 2>/dev/null
-	ipset -X music_https 2>/dev/null
-	
-	rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
-	/etc/init.d/dnsmasq reload >/dev/null 2>&1
+    fi
+    $ipt_n -F CLOUD_MUSIC 2>/dev/null
+    $ipt_n -X CLOUD_MUSIC 2>/dev/null
+    iptables -D OUTPUT -d 223.252.199.10 -j DROP 2>/dev/null
+
+    ipset flush music 2>/dev/null
+    ipset -X music_http 2>/dev/null
+    ipset -X music_https 2>/dev/null
+    ipset -X music_proxy_http 2>/dev/null
+    ipset -X music_proxy_https 2>/dev/null
+
+    rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
+    /etc/init.d/dnsmasq reload >/dev/null 2>&1
 }
 
 set_firewall(){
-	rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
-	mkdir -p /tmp/dnsmasq.d
+    rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
+    mkdir -p /tmp/dnsmasq.d
   	cat <<-EOF > "/tmp/dnsmasq.d/dnsmasq-163.conf"
 ipset=/.music.163.com/music
 ipset=/interface.music.163.com/music
@@ -141,83 +179,83 @@ ipset=/apm3.music.163.com/music
 ipset=/clientlog.music.163.com/music
 ipset=/clientlog3.music.163.com/music
 	EOF
-	/etc/init.d/dnsmasq reload >/dev/null 2>&1
-	
-	add_rule
-	
-	mkdir -p /var/etc
-	echo -e "/etc/init.d/unblockmusic restart" > "/var/etc/unblockmusic.include"
+    /etc/init.d/dnsmasq reload >/dev/null 2>&1
+
+    add_rule
+
+    mkdir -p /var/etc
+    echo -e "/etc/init.d/unblockmusic restart" > "/var/etc/unblockmusic.include"
 }
 
 add_cron()
 {
-	if [ $AUTOUPDATE -eq 1 ]; then
-		sed -i '/update_core.sh/d' $CRON_FILE
-		echo '0 2 * * * /usr/share/UnblockNeteaseMusic/update_core.sh 2>&1' >> $CRON_FILE
-		crontab $CRON_FILE
-	fi
+    if [ $AUTOUPDATE -eq 1 ]; then
+        sed -i '/update_core.sh/d' $CRON_FILE
+        echo '0 2 * * * /usr/share/UnblockNeteaseMusic/update_core.sh 2>&1' >> $CRON_FILE
+        crontab $CRON_FILE
+    fi
 }
 
 del_cron()
 {
-	sed -i '/update_core.sh/d' $CRON_FILE
-	/etc/init.d/cron restart
+    sed -i '/update_core.sh/d' $CRON_FILE
+    /etc/init.d/cron restart
 }
 
 start()
 {
-	stop
-	
-	[ $ENABLE -eq "0" ] && exit 0
-		
-	rm -f /tmp/unblockmusic.log
-	echo "$(date -R) # Start UnblockNeteaseMusic" >/tmp/unblockmusic.log
-	
-	if [ "$TYPE" = "default" ]; then
-		musictype=" "
-	else
-		musictype="-o $TYPE"
-	fi
-	
-  if [ "$APPTYPE" == "nodejs" ]; then
-    if [ $FLAC -eq 1 ]; then
-      export ENABLE_FLAC=true
-    fi
-    if [ $REPLACE_MUSIC_SOURCE -ne 0 ]; then
-      export MIN_BR=$REPLACE_MUSIC_SOURCE
-    fi
-	if [ $LOCAL_VIP -eq 1 ]; then
-      export ENABLE_LOCAL_VIP=true
-    fi
-    node /usr/share/UnblockNeteaseMusic/app.js -p 5200 $musictype >>/tmp/unblockmusic.log 2>&1 &
-    node /usr/share/UnblockNeteaseMusic/app.js -e https://music.163.com -p 5203:5201 $musictype >>/tmp/unblockmusic.log 2>&1 &
-    add_cron
-    echo "$(date -R) # UnblockNeteaseMusic Nodejs Version (http:5200, https:5201)" >>/tmp/unblockmusic.log  
-  elif [ "$APPTYPE" == "go" ]; then
-    if [ $FLAC -eq 1 ]; then
-      ENABLE_FLAC="-b "
-    fi
-    UnblockNeteaseMusic -o "kuwo:kugou" $ENABLE_FLAC -p 5200 -sp 5201 -c /usr/share/UnblockNeteaseMusicGo/server.crt -k /usr/share/UnblockNeteaseMusicGo/server.key -m 0 -e -sl ${SEARCHLIMIT} -l /tmp/unblockmusic.log &
-    echo "$(date -R) # UnblockNeteaseMusic Golang Version (http:5200, https:5201)" >>/tmp/unblockmusic.log
+    stop
+
+    [ $ENABLE -eq "0" ] && exit 0
+
+    rm -f /tmp/unblockmusic.log
+    echo "$(date -R) # Start UnblockNeteaseMusic" >/tmp/unblockmusic.log
+
+    if [ "$TYPE" = "default" ]; then
+        musictype=" "
     else
-    kill -9 $(busybox ps -w | grep 'sleep 60m' | grep -v grep | awk '{print $1}') >/dev/null 2>&1
-    /usr/bin/UnblockNeteaseMusicCloud >/dev/null 2>&1 &
-     echo "$(date -R) # UnblockNeteaseMusic Cloud Version - Server: $cloudip (http:$cloudhttp, https:$cloudhttps)" >>/tmp/unblockmusic.log
-  fi
-		
-	set_firewall
-	
-  if [ "$APPTYPE" != "cloud" ]; then
-    /usr/share/UnblockNeteaseMusic/logcheck.sh >/dev/null 2>&1 &
-  fi
+        musictype="-o $TYPE"
+    fi
+
+    if [ "$APPTYPE" == "nodejs" ]; then
+        if [ $FLAC -eq 1 ]; then
+            export ENABLE_FLAC=true
+        fi
+        if [ $REPLACE_MUSIC_SOURCE -ne 0 ]; then
+            export MIN_BR=$REPLACE_MUSIC_SOURCE
+        fi
+        if [ $LOCAL_VIP -eq 1 ]; then
+            export ENABLE_LOCAL_VIP=true
+        fi
+        node /usr/share/UnblockNeteaseMusic/app.js -p 5200 $musictype >>/tmp/unblockmusic.log 2>&1 &
+        node /usr/share/UnblockNeteaseMusic/app.js -e https://music.163.com -p 5203:5201 $musictype >>/tmp/unblockmusic.log 2>&1 &
+        add_cron
+        echo "$(date -R) # UnblockNeteaseMusic Nodejs Version (http:5200, https:5201)" >>/tmp/unblockmusic.log
+    elif [ "$APPTYPE" == "go" ]; then
+        if [ $FLAC -eq 1 ]; then
+            ENABLE_FLAC="-b "
+        fi
+        UnblockNeteaseMusic -o "kuwo:kugou" $ENABLE_FLAC -p 5200 -sp 5201 -c /usr/share/UnblockNeteaseMusicGo/server.crt -k /usr/share/UnblockNeteaseMusicGo/server.key -m 0 -e -sl ${SEARCHLIMIT} -l /tmp/unblockmusic.log &
+        echo "$(date -R) # UnblockNeteaseMusic Golang Version (http:5200, https:5201)" >>/tmp/unblockmusic.log
+    else
+        kill -9 $(busybox ps -w | grep 'sleep 60m' | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+        /usr/bin/UnblockNeteaseMusicCloud >/dev/null 2>&1 &
+        echo "$(date -R) # UnblockNeteaseMusic Cloud Version - Server: $cloudip (http:$cloudhttp, https:$cloudhttps)" >>/tmp/unblockmusic.log
+    fi
+
+    set_firewall
+
+    if [ "$APPTYPE" != "cloud" ]; then
+        /usr/share/UnblockNeteaseMusic/logcheck.sh >/dev/null 2>&1 &
+    fi
 }
 
 stop()
-{	
-	kill -9 $(busybox ps -w | grep UnblockNeteaseMusic | grep -v grep | awk '{print $1}') >/dev/null 2>&1
-	kill -9 $(busybox ps -w | grep logcheck.sh | grep -v grep | awk '{print $1}') >/dev/null 2>&1
-	rm -f /tmp/unblockmusic.log
-	
-	del_rule
-	del_cron
+{
+    kill -9 $(busybox ps -w | grep UnblockNeteaseMusic | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+    kill -9 $(busybox ps -w | grep logcheck.sh | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+    rm -f /tmp/unblockmusic.log
+
+    del_rule
+    del_cron
 }

--- a/applications/luci-app-unblockmusic/root/usr/bin/UnblockNeteaseMusicCloud
+++ b/applications/luci-app-unblockmusic/root/usr/bin/UnblockNeteaseMusicCloud
@@ -2,7 +2,7 @@
 
 while true
 do
-  ipset -! -N music hash:ip
+  ipset -! flush music
   uclient-fetch -q -T 10 http://httpdns.n.netease.com/httpdns/v2/d?domain=music.163.com,interface.music.163.com,interface3.music.163.com,apm.music.163.com,apm3.music.163.com,clientlog.music.163.com,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | awk '{print "ipset -! add music "$1}' | sh
 	sleep 60m
 done


### PR DESCRIPTION
luci-app-unblockmusic: add white mode:

This PR added the white mode to luci-app-unblockmusic, which allows users to only proxy specfic devices and bypass other devices. This PR also moved the function to get LAN address out of global scope, to avoid some compile errors (but not fatal).

luci-app-unblockmusic: fix cloud mode ssl cert error on other website:

This PR fixed the rare ssl certificate error when opening websites other than netease cloud music, especially when luci-app-unblockmusic is running for a long time. This is because the cloud script did not clean the IPs added to the proxy ipset, and those IPs can belong to other websites when time goes by.