### PR TITLE
luci-app-music-remote-center: add init missing parameter `-b`

### DIFF
--- a/applications/luci-app-music-remote-center/root/etc/init.d/owntone
+++ b/applications/luci-app-music-remote-center/root/etc/init.d/owntone
@@ -50,7 +50,7 @@ start() {
         gen_config_file
         local enabled=$(uci_get_by_type owntone enabled 0)
         [ "$enabled" == "0" ] && return 1
-        $SSD -p $PID -S -x $BIN -- -P $PID -c /var/etc/owntone.conf
+        $SSD -p $PID -S -b -x $BIN -- -P $PID -c /var/etc/owntone.conf
 }
 	
 stop() {


### PR DESCRIPTION
`/etc/init.d/owntone`中start-stop-daemon参数缺失`-b`，无法在后台运行，owntone无法正确创建PID文件

Signed-off-by: Yu Hua <hue715@gmail.com>