### PR TITLE
luci-app-qbittorrent: update zh-cn translation

### DIFF
--- a/applications/luci-app-qbittorrent/po/zh-cn/qbittorrent.po
+++ b/applications/luci-app-qbittorrent/po/zh-cn/qbittorrent.po
@@ -155,9 +155,6 @@ msgstr "使用路由器的 UPnP/NAT-PMP 端口自动转发。"
 msgid "Use different port on each startup voids the first"
 msgstr "在每次启动时使用随机的端口，可能会使第一个启动无效"
 
-msgid "Generate Randomly"
-msgstr "默认端口：8999"
-
 msgid "Global Download Speed"
 msgstr "全局下载速度限制"
 


### PR DESCRIPTION
qb里面根本就没用到"Generate Randomly"，而且还翻译成"默认端口：8999"，导致其他插件的翻译错误！