### PR TITLE
luci-app-ssrserver-python:Fix server startup failure caused by Python library changes

### DIFF
--- a/applications/luci-app-ssrserver-python/root/usr/share/ssr/shadowsocks/lru_cache.py
+++ b/applications/luci-app-ssrserver-python/root/usr/share/ssr/shadowsocks/lru_cache.py
@@ -41,7 +41,7 @@ except:
 
 SWEEP_MAX_ITEMS = 1024
 
-class LRUCache(collections.MutableMapping):
+class LRUCache(collections.abc.MutableMapping):
     """This class is not thread safe"""
 
     def __init__(self, timeout=60, close_callback=None, *args, **kwargs):


### PR DESCRIPTION
change collections.MutableMapping to collections.abc.MutableMapping

This PR closes #225 