### PR TITLE
luci-app-mosdns: Fix ".site" domain name cannot be resolved

### DIFF
--- a/applications/luci-app-mosdns/root/usr/share/mosdns/sp_low.tdata
+++ b/applications/luci-app-mosdns/root/usr/share/mosdns/sp_low.tdata
@@ -13,7 +13,6 @@
 #
 #      (1) site
 #
-Site
 agiftcard724.com
 poopthree.com
 shell.rddos.com


### PR DESCRIPTION
Because the file contains a separate entry for "Site", all "*.site" domains cannot be resolved.