### PR TITLE
Delete conflict luci-app-socat configuration file

### DIFF
--- a/applications/luci-app-socat/root/etc/config/socat
+++ b/applications/luci-app-socat/root/etc/config/socat
@@ -1,3 +1,0 @@
-
-config global 'global'
-	option enable '0'


### PR DESCRIPTION
Delete the configuration file that conflicts with `socat` in `luci-app-socat`.
