### PR TITLE
luci-proto-ipv6: add ipip6 support

### DIFF
--- a/modules/luci-base/po/zh-cn/base.po
+++ b/modules/luci-base/po/zh-cn/base.po
@@ -1525,6 +1525,15 @@ msgstr "IPv6 后缀"
 msgid "IPv6-Address"
 msgstr "IPv6 地址"
 
+msgid "Remote IPv6 address"
+msgstr "远程 IPv6 地址"
+
+msgid "Encapsulation limit"
+msgstr "封装限制"
+
+msgid "When delegating prefixes to multiple downstreams, interfaces with a higher preference value are considered first when allocating subnets."
+msgstr "将前缀委派给多个下游时，在分配子网时，将首先考虑具有较高优先级值的接口。"
+
 msgid "IPv6-PD"
 msgstr "IPv6-PD"
 

--- a/protocols/luci-proto-ipv6/Makefile
+++ b/protocols/luci-proto-ipv6/Makefile
@@ -6,7 +6,7 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite/aiccu
+LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite/IPIP6/aiccu
 LUCI_DEPENDS:=
 
 PKG_LICENSE:=Apache-2.0

--- a/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_ipip6.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/cbi/admin_network/proto_ipip6.lua
@@ -1,0 +1,65 @@
+local map, section, net = ...
+local peeraddr, ip4ifaddr, ip6addr
+local tunlink, encaplimit, defaultroute, metric, mtu
+
+peeraddr = section:taboption("general", Value, "peeraddr", translate("Remote IPv6 address"))
+peeraddr.datatype = "ip6addr"
+peeraddr.rmempty  = false
+
+ip4ifaddr = section:taboption("general", Value, "ip4ifaddr", translate("Local IPv4 address"))
+ip4ifaddr.datatype = "ip4addr"
+ip4ifaddr.rmempty  = false
+
+ip6addr = section:taboption("general", Value, "ip6addr", translate("Local IPv6 address"), translate("Leave empty to use the current WAN address"))
+ip6addr.datatype = "ip6addr"
+ip6addr.rmempty = true
+
+tunlink = section:taboption("advanced", DynamicList, "tunlink", translate("Tunnel Link"))
+tunlink.template = "cbi/network_netlist"
+tunlink.nocreate = true
+
+encaplimit = section:taboption("advanced", Value, "encaplimit", translate("Encapsulation limit"))
+for i = 0, 255 do
+    encaplimit:value(tostring(i))
+end
+encaplimit:value("ignore")
+encaplimit.default = "ignore"
+encaplimit.rmempty = false
+
+defaultroute = section:taboption("advanced", Flag, "defaultroute", translate("Default gateway"), translate("If unchecked, no default route is configured"))
+defaultroute.default = defaultroute.enabled
+
+ip6assign = section:taboption("advanced", Value, "ip6assign", translate("IPv6 assignment length"),
+		translate("Assign a part of given length of every public IPv6-prefix to this interface"))
+ip6assign:value("", translate("disabled"))
+ip6assign:value("64")
+ip6assign.datatype = "max(128)"
+
+ip6hint = section:taboption("advanced", Value, "ip6hint", translate("IPv6 assignment hint"),
+		translate("Assign prefix parts using this hexadecimal subprefix ID for this interface."))
+for i=33,64 do ip6hint:depends("ip6assign", i) end
+
+
+ip6hint = section:taboption("advanced", Value, "ip6prefix",
+	translate("Custom delegated IPv6-prefix"))
+ip6hint.dataype = "ip6addr"
+
+ip6ifaceid = section:taboption("advanced", Value, "ip6ifaceid",
+	translate("IPv6 suffix"), translate("Optional. Allowed values: 'eui64', 'random', fixed value like '::1' or '::1:2'. When IPv6 prefix (like 'a:b:c:d::') is received from a delegating server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') for the interface."))
+ip6ifaceid.dataype = "ip6hostid"
+ip6ifaceid.placeholder = "::1"
+ip6ifaceid.rmempty = true
+
+ip6weight = section:taboption("advanced", Value, "ip6weight",
+	translate("IPv6 preference"), translate("When delegating prefixes to multiple downstreams, interfaces with a higher preference value are considered first when allocating subnets."))
+ip6weight.dataype = "uinteger"
+ip6weight.placeholder = "0"
+
+metric = section:taboption("advanced", Value, "metric", translate("Use gateway metric"))
+metric.datatype = "uinteger"
+metric:depends("defaultroute", defaultroute.enabled)
+metric.placeholder = "0"
+
+mtu = section:taboption("advanced", Value, "mtu", translate("Use MTU on tunnel interface"))
+mtu.datatype = "max(9200)"
+mtu.placeholder = "1280"

--- a/protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua
+++ b/protocols/luci-proto-ipv6/luasrc/model/network/proto_4x6.lua
@@ -5,13 +5,15 @@
 local netmod = luci.model.network
 
 local _, p
-for _, p in ipairs({"dslite", "map", "464xlat"}) do
+for _, p in ipairs({"dslite", "map", "464xlat", "ipip6"}) do
 
 	local proto = netmod:register_protocol(p)
 
 	function proto.get_i18n(self)
 		if p == "dslite" then
 			return luci.i18n.translate("Dual-Stack Lite (RFC6333)")
+		elseif p == "ipip6" then
+			return luci.i18n.translate("IPv4 over IPv6 (ipip6)")
 		elseif p == "map" then
 			return luci.i18n.translate("MAP / LW4over6")
 		elseif p == "464xlat" then
@@ -26,6 +28,8 @@ for _, p in ipairs({"dslite", "map", "464xlat"}) do
 	function proto.opkg_package(self)
 		if p == "dslite" then
 			return "ds-lite"
+		elseif p == "ipip6" then
+			return "ipip6"
 		elseif p == "map" then
 			return "map-t"
 		elseif p == "464xlat" then
@@ -55,6 +59,8 @@ for _, p in ipairs({"dslite", "map", "464xlat"}) do
 
 	if p == "dslite" then
 		netmod:register_pattern_virtual("^ds%-%w")
+	elseif p == "ipip6" then
+		netmod:register_pattern_virtual("^ipip6%-%w")
 	elseif p == "map" then
 		netmod:register_pattern_virtual("^map%-%w")
 	elseif p == "464xlat" then


### PR DESCRIPTION
Add IPIP6(RFC2473) support

[coolsnowwolf/lede#11970](https://github.com/coolsnowwolf/lede/pull/11970)