### PR TITLE
Revert "fix: /etc/config/zero are incorrectly written to flash"

### DIFF
--- a/applications/luci-app-zerotier/root/etc/init.d/zerotier
+++ b/applications/luci-app-zerotier/root/etc/init.d/zerotier
@@ -27,9 +27,8 @@ start_instance() {
 		return 1
 	fi
   
-	config_path=${CONFIG_PATH}_$cfg
-	rm -rf $config_path
-	mkdir -p $config_path
+  [ -d /etc/config/zero ] || mkdir -p /etc/config/zero
+  config_path=/etc/config/zero
   
 	config_get_bool port $cfg 'port'
 	config_get secret $cfg 'secret'


### PR DESCRIPTION
Reverts coolsnowwolf/luci#269
https://github.com/coolsnowwolf/luci/commit/c0ab8ee0cf5e1f99075ae63bcec5298bef85830e
https://github.com/coolsnowwolf/lede/issues/11974

错误地删除了所有的配置文件，导致重启后无法恢复连接。