### PR TITLE
luci-app-mwan3: fix status page issue

### DIFF
--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_detail.htm
@@ -13,6 +13,7 @@
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/status/mwan/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>
 
+<script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript">//<![CDATA[
 	XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "detailed_status")%>', null,
 		function(x)

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_diagnostics.htm
@@ -25,6 +25,7 @@
 	)
 %>
 
+<script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript">//<![CDATA[
 	var stxhr = new XHR();
 

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_interface.htm
@@ -6,6 +6,7 @@
 
 <%+header%>
 
+<script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <ul class="cbi-tabmenu">
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/status/mwan/overview")%>"><%:Interface%></a></li>
 	<li class="cbi-tab-disabled"><a href="<%=luci.dispatcher.build_url("admin/status/mwan/detail")%>"><%:Detail%></a></li>

--- a/applications/luci-app-mwan3/luasrc/view/mwan/status_troubleshooting.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/status_troubleshooting.htm
@@ -13,6 +13,7 @@
 	<li class="cbi-tab"><a href="<%=luci.dispatcher.build_url("admin/status/mwan/troubleshooting")%>"><%:Troubleshooting%></a></li>
 </ul>
 
+<script type="text/javascript" src="<%=resource%>/cbi.js"></script>
 <script type="text/javascript">//<![CDATA[
 	XHR.poll(15, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "troubleshooting_display")%>', null,
 		function(x)


### PR DESCRIPTION
mwan3状态页面无限加载，经排查发现是mwan3状态的四个tab都没有加载cbi.js导致