### PR TITLE
luci-app-pptp-server: fix typo error

### DIFF
--- a/applications/luci-app-pptp-server/luasrc/model/cbi/pptp-server.lua
+++ b/applications/luci-app-pptp-server/luasrc/model/cbi/pptp-server.lua
@@ -1,6 +1,6 @@
 mp = Map("pptpd")
 mp.title = translate("PPTP VPN Server")
-mp.description = translate("PPTP VPN Server connectivity using the native built-in VPN Client on Windows/Linux or Andriod")
+mp.description = translate("PPTP VPN Server connectivity using the native built-in VPN Client on Windows/Linux or Android")
 
 mp:section(SimpleSection).template  = "pptp-server/pptp-server_status"
 


### PR DESCRIPTION
### Fix a spelling error

`Andriod` => `Android`

### Related

The po file [pptp.po](/coolsnowwolf/luci/blob/master/applications/luci-app-pptp-server/po/zh-cn/pptp.po) has fixed via 6113678abfc4b587b3e3d12517b54bd35d061819.