### PR TITLE
luci-mod-admin-full: greatly improved WiFi scan page display

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
@@ -95,24 +95,28 @@
 <div class="cbi-map">
 	<fieldset class="cbi-section">
 		<table class="cbi-section-table" style="empty-cells:hide">
+			<tr class="cbi-section-table-titles">
+				<th class="cbi-section-table-cell" style="text-align: center;"><%:Signal%></th>
+				<th class="cbi-section-table-cell">SSID</th>
+				<th class="cbi-section-table-cell" style="text-align: center;"><%:Channel%></th>
+				<th class="cbi-section-table-cell"><%:Mode%></th>
+				<th class="cbi-section-table-cell">BSSID</th>
+				<th class="cbi-section-table-cell"><%:Encryption%></th>
+				<th class="cbi-section-table-cell" style="text-align: center;"><%:Action%></th>
+			</tr>
 			<!-- scan list -->
 			<% for i, net in ipairs(scanlist(1)) do net.encryption = net.encryption or { } %>
 			<tr class="cbi-section-table-row cbi-rowstyle-<%=1 + ((i-1) % 2)%>">
-				<td class="cbi-value-field" style="width:16px; padding:3px">
-					<abbr title="<%:Signal%>: <%=net.signal%> <%:dB%> / <%:Quality%>: <%=net.quality%>/<%=net.quality_max%>">
-						<img src="<%=guess_wifi_signal(net)%>" /><br />
-						<small><%=percent_wifi_signal(net)%>%</small>
-					</abbr>
+				<td class="cbi-value-field" style="vertical-align: middle; text-align: center; padding: 5px 10px 5px;">
+					<span title="<%=percent_wifi_signal(net)%>%" class="ifacebadge" style="padding: 2px 5px; background-image: none; background-color: transparent;"><img src="<%=guess_wifi_signal(net)%>"><span style="margin-left: 6px;"><%=net.signal%> dBm</span></span>
 				</td>
-				<td class="cbi-value-field" style="vertical-align:middle; text-align:left; padding:3px">
-					<big><strong><%=net.ssid and utl.pcdata(net.ssid) or "<em>%s</em>" % translate("hidden")%></strong></big><br />
-					<strong>Channel:</strong> <%=net.channel%> |
-					<strong>Mode:</strong> <%=net.mode%> |
-					<strong>BSSID:</strong> <%=net.bssid%> |
-					<strong>Encryption:</strong> <%=format_wifi_encryption(net.encryption)%>
-				</td>
-				<td class="cbi-value-field" style="width:40px">
-					<form action="<%=url('admin/network/wireless_join')%>" method="post">
+				<td class="cbi-value-field" style="vertical-align: middle; padding: 5px 10px 5px;"><%=net.ssid and utl.pcdata(net.ssid) or "<em>%s</em>" % translate("hidden")%></td>
+				<td class="cbi-value-field" style="vertical-align: middle; text-align: center; padding: 5px 10px 5px;"><%=net.channel%></td>
+				<td class="cbi-value-field" style="vertical-align: middle; padding: 5px 10px 5px;"><%=net.mode%></td>
+				<td class="cbi-value-field" style="vertical-align: middle; padding: 5px 10px 5px;"><%=net.bssid%></td>
+				<td class="cbi-value-field" style="vertical-align: middle; padding: 5px 10px 5px;"><%=format_wifi_encryption(net.encryption)%></td>
+				<td class="cbi-value-field" style="vertical-align: middle; text-align: center; padding: 5px 10px 5px;">
+					<form action="<%=url('admin/network/wireless_join')%>" method="post" style="margin-top:3px; margin-bottom:3px;">
 						<input type="hidden" name="token" value="<%=token%>" />
 						<input type="hidden" name="device" value="<%=utl.pcdata(dev)%>" />
 						<input type="hidden" name="join" value="<%=utl.pcdata(net.ssid)%>" />


### PR DESCRIPTION
## luci-mod-admin-full

改进 WiFi 扫描结果页面的样式效果，调整为跟 `24.10` 一样的 table 结构。

> 主打一个新版有的旧版也能有，修修补补又三年！

### Original
![wifi_join_ori](https://github.com/user-attachments/assets/bbe5dd5a-7a82-4d1a-acf7-b74ad4220e36)

> 信号强度居然没有直接显示！！怎么过的，这些年。

### Improved
![wifi_join_newUI](https://github.com/user-attachments/assets/6a81f220-7f13-4c8c-a2ee-a0d6efe6a3a4)

> 这下直观多了~~

### 24.10
![wifi_join_2410](https://github.com/user-attachments/assets/7bdd4d82-579c-4e5d-b758-5055a3cab760)