### PR TITLE
luci-base: improve interface page display

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -657,12 +657,18 @@ function _create_node(path)
 		local last = table.remove(path)
 		local parent = _create_node(path)
 
-		c = {nodes={}, auto=true}
-		-- the node is "in request" if the request path matches
-		-- at least up to the length of the node path
-		if parent.inreq and context.path[#path+1] == last then
-		  c.inreq = true
+		c = {nodes={}, auto=true, inreq=true}
+
+		local _, n
+		for _, n in ipairs(path) do
+			if context.path[_] ~= n then
+				c.inreq = false
+				break
+			end
 		end
+
+		c.inreq = c.inreq and (context.path[#path + 1] == last)
+
 		parent.nodes[last] = c
 		context.treecache[name] = c
 	end


### PR DESCRIPTION
## luci-base

`18.06`的陈年 Bug，还是修复一下，主打一个`修修补补又三年`。

> inreq 的初始化问题，主要影响 `Network` 和 `Wireless` 两个页面的 TabMenu 渲染。

![LEDE-NoTabMenu](https://github.com/user-attachments/assets/f38e7a75-3b1e-46d4-a352-88984665ec70)

有这个 TabMenu，页面操作还是会方便很多：

![LEDE-TabMenu-Wireless2](https://github.com/user-attachments/assets/534fff1a-1592-48ce-a757-18f23881453c)
