### PR TITLE
luci-app-ddns-go: add config and init 

### DIFF
--- a/applications/luci-app-ddns-go/Makefile
+++ b/applications/luci-app-ddns-go/Makefile
@@ -10,6 +10,11 @@ LUCI_PKGARCH:=all
 
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
+define Package/ddns-go/conffiles
+/etc/config/ddns-go
+/etc/init.d/ddns-go
+endef
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ddns-go/root/etc/config/ddns-go
+++ b/applications/luci-app-ddns-go/root/etc/config/ddns-go
@@ -1,0 +1,7 @@
+
+config ddns-go 'config'
+	option enabled '0'
+	option listen '[::]:9876'
+	option ttl '300'
+	option noweb '0'
+	option insecure '0'

--- a/applications/luci-app-ddns-go/root/etc/init.d/ddns-go
+++ b/applications/luci-app-ddns-go/root/etc/init.d/ddns-go
@@ -1,0 +1,48 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2023 ImmortalWrt.org
+
+START=99
+USE_PROCD=1
+
+CONF="ddns-go"
+YAML="/etc/$CONF/config.yaml"
+PROG="/usr/bin/$CONF"
+
+start_service() {
+	config_load "$CONF"
+
+	local enabled
+	config_get_bool enabled "config" "enabled" "0"
+	[ "$enabled" -eq "1" ] || return 1
+
+	local listen ttl dns noweb insecure
+	config_get listen "config" "listen" "[::]:9876"
+	config_get ttl "config" "ttl" "300"
+	config_get dns "config" "dns"
+	config_get_bool noweb "config" "noweb" "0"
+	config_get_bool insecure "config" "insecure" "0"
+
+	[ -d "${YAML%/*}" ] || mkdir -p "${YAML%/*}"
+	touch "$YAML"
+	chown ddns-go "${YAML%/*}"
+	chown ddns-go "$YAML"
+
+	procd_open_instance "$CONF"
+	procd_set_param command "$PROG"
+	procd_append_param command -c "$YAML"
+	procd_append_param command -l "$listen"
+	procd_append_param command -f "$ttl"
+	[ -z "$dns" ] || procd_append_param command -dns "$dns"
+	[ "$noweb" -eq "0" ] || procd_append_param command -noweb
+	[ "$insecure" -eq "0" ] || procd_append_param command -skipVerify
+
+	procd_set_param respawn
+	procd_set_param stderr 1
+	procd_set_param user ddns-go
+
+	procd_close_instance
+}
+
+service_triggers() {
+	procd_add_reload_trigger "$CONF"
+}

--- a/applications/luci-app-ddns-go/root/etc/uci-defaults/ddns-go-permissions
+++ b/applications/luci-app-ddns-go/root/etc/uci-defaults/ddns-go-permissions
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ -x "/etc/init.d/ddns-go" ] || chmod +x /etc/init.d/ddns-go
+
+exit 0


### PR DESCRIPTION
Used commit cfa7fb1 from 23.05, compiled successfully.