### PR TITLE
luci-lib-nixio: always build without TLS support

### DIFF
--- a/libs/luci-lib-nixio/Makefile
+++ b/libs/luci-lib-nixio/Makefile
@@ -7,47 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=NIXIO POSIX library
-LUCI_DEPENDS:=+PACKAGE_luci-lib-nixio_openssl:libopenssl +PACKAGE_luci-lib-nixio_cyassl:libcyassl +liblua
+LUCI_DEPENDS:=+liblua
 
 PKG_LICENSE:=Apache-2.0
-
-define Package/luci-lib-nixio/config
-	choice
-		prompt "TLS Provider"
-		default PACKAGE_luci-lib-nixio_openssl
-
-		config PACKAGE_luci-lib-nixio_notls
-			bool "Disabled"
-
-		config PACKAGE_luci-lib-nixio_axtls
-			bool "Builtin (axTLS)"
-
-		config PACKAGE_luci-lib-nixio_cyassl
-			bool "CyaSSL"
-			select PACKAGE_libcyassl
-
-		config PACKAGE_luci-lib-nixio_openssl
-			bool "OpenSSL"
-			select PACKAGE_libopenssl
-	endchoice
-endef
-
-NIXIO_TLS:=
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_axtls),)
-  NIXIO_TLS:=axtls
-endif
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_openssl),)
-  NIXIO_TLS:=openssl
-endif
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_cyassl),)
-  NIXIO_TLS:=cyassl
-  LUCI_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
-endif
-
-MAKE_VARS += NIXIO_TLS="$(NIXIO_TLS)"
 
 include ../../luci.mk
 

--- a/libs/luci-lib-nixio/axTLS/www/index.html
+++ b/libs/luci-lib-nixio/axTLS/www/index.html
@@ -1,10 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<script type="text/javascript">
-//<![CDATA[
+<script>
 var version = {major: 2, minor: 1, revision: 3, date: new Date("Nov 3, 2006"), extensions: {}};
-//]]>
 </script>
 <!--
 TiddlyWiki 2.1.3 by Jeremy Ruston, (jeremy [at] osmosoft [dot] com)
@@ -36,15 +34,14 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 -->
-<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+<meta charset="utf-8"/>
 <!--PRE-HEAD-START-->
 <!--{{{-->
 <link rel='alternate' type='application/rss+xml' title='RSS' href='index.xml'/>
 <!--}}}-->
 <!--PRE-HEAD-END-->
 <title> axTLS Embedded SSL - changes, notes and errata </title>
-<script type="text/javascript">
-//<![CDATA[
+<script>
 // ---------------------------------------------------------------------------------
 // Configuration repository
 // ---------------------------------------------------------------------------------
@@ -5943,10 +5940,10 @@ String.prototype.htmlEncode = function()
 	return(this.replace(/&/mg,"&amp;").replace(/</mg,"&lt;").replace(/>/mg,"&gt;").replace(/\"/mg,"&quot;"));
 }
 
-// Convert "&amp;" to &, "&lt;" to <, "&gt;" to > and "&quot;" to "
+// Convert "&lt;" to <, "&gt;" to >, "&quot;" to " and "&amp;" to & (& handled last for security reasons)
 String.prototype.htmlDecode = function()
 {
-	return(this.replace(/&amp;/mg,"&").replace(/&lt;/mg,"<").replace(/&gt;/mg,">").replace(/&quot;/mg,"\""));
+	return(this.replace(/&lt;/mg,"<").replace(/&gt;/mg,">").replace(/&quot;/mg,"\"").replace(/&amp;/mg,"&"));
 }
 
 // Parse a space-separated string of name:value parameters where:
@@ -7013,9 +7010,8 @@ merge(config.shadowTiddlers,{SiteSubtitle:"a theme for ~TiddlyWiki"});
 merge(config.shadowTiddlers,{DefaultTiddlers:"LorumIpsum"});
 merge(config.shadowTiddlers,{LorumIpsum:"Aenean eros arcu, condimentum nec, dapibus ut, tincidunt sit amet, urna. Quisque viverra, eros sed imperdiet iaculis, est risus facilisis quam, id malesuada arcu nulla luctus urna. Nullam et est. Vestibulum velit sem, faucibus cursus, dapibus vestibulum, pellentesque et, urna. Donec luctus. Donec lectus. Aliquam eget eros facilisis tortor feugiat sollicitudin. Integer lobortis vulputate sapien. Sed iaculis erat ac nunc. Etiam eu enim. Mauris ipsum urna, rhoncus at, bibendum sit amet, euismod eget, dolor. Mauris fermentum quam vitae ligula. Vestibulum in libero feugiat justo dictum consectetuer. Vestibulum euismod purus eget elit. Nunc sed massa porta elit bibendum posuere. Nunc pulvinar justo sit amet odio. In sed est. Phasellus ornare elementum nulla. Nulla ipsum neque, cursus a, viverra a, imperdiet at, enim. Quisque facilisis, diam sed accumsan suscipit, odio arcu hendrerit dolor, quis aliquet massa nulla nec sem.\n!heading 1\n!!heading 2\n!!!heading3\n----\n<<tag button>>\nThis is a link to a [[StyleSheet]] tiddler.\n\n> This is a blockquote\n> This is a blockquote\n> This is a blockquote\n|>|>| !This is a header |h\n|column1|column2|column3|\n|row2| row2 |row2|\n|column1|column2|column3|\n|row2| row2 |row2|\n|column1|column2|column3|\n|row2| row2 |row2|"});
 // ---------------------------------------------------------------------------------
-//]]>
 </script>
-<style type="text/css">
+<style>
 
 #saveTest {
 	display: none;
@@ -7069,11 +7065,9 @@ merge(config.shadowTiddlers,{LorumIpsum:"Aenean eros arcu, condimentum nec, dapi
 <!--PRE-BODY-START-->
 
 <!--PRE-BODY-END-->
-	<script type="text/javascript">
-//<![CDATA[
+	<script>
 if (useJavaSaver)
 	document.write("<applet style='position:absolute;left:-1px' name='TiddlySaver' code='TiddlySaver.class' archive='TiddlySaver.jar' width='1' height='1'></applet>");
-//]]>
 	</script>
 	<div id="copyright">
 	Welcome to TiddlyWiki by Jeremy Ruston, Copyright &copy; 2006 Osmosoft Limited

--- a/libs/luci-lib-nixio/docsrc/CHANGELOG.lua
+++ b/libs/luci-lib-nixio/docsrc/CHANGELOG.lua
@@ -10,7 +10,7 @@ module "nixio.CHANGELOG"
 -- <li>Added support for x509 certificates in DER format.</li>
 -- <li>Added support for splice() in UnifiedIO.copyz().</li>
 -- <li>Added interface to inject chunks into UnifiedIO.linesource() buffer.</li>
--- <li>Changed TLS behaviour to explicitely separate servers and clients.</li>
+-- <li>Changed TLS behaviour to explicitly separate servers and clients.</li>
 -- <li>Fixed usage of signed datatype breaking Base64 decoding.</li>
 -- <li>Fixed namespace clashes for nixio.fs.</li>
 -- <li>Fixed splice() support for some exotic C libraries.</li>

--- a/libs/luci-lib-nixio/docsrc/README.lua
+++ b/libs/luci-lib-nixio/docsrc/README.lua
@@ -18,7 +18,7 @@ module "nixio.README"
 -- table <strong>nixio.const_sock</strong> for socket error codes. This might
 -- be important if you are dealing with Windows applications, on POSIX however
 -- const_sock is just an alias for const.</li>
--- <li>With some exceptions - which are explicitely stated in the function
+-- <li>With some exceptions - which are explicitly stated in the function
 -- documentation - all blocking functions are signal-protected and will not fail
 -- with EINTR.</li>
 -- <li>On POSIX the SIGPIPE signal will be set to ignore upon initialization.
@@ -33,7 +33,7 @@ module "nixio.README"
 -- <br />In general all functions are namend and behave like their POSIX API
 -- counterparts - where applicable - applying the following rules:
 -- <ul>
--- <li>Functions should be named like the underlying POSIX API function ommiting
+-- <li>Functions should be named like the underlying POSIX API function omitting
 -- prefixes or suffixes - especially when placed in an object-context (
 -- lockf -> File:lock, fsync -> File:sync, dup2 -> dup, ...)</li>
 -- <li>If you are unclear about the behaviour of a function you should consult
@@ -41,10 +41,10 @@ module "nixio.README"
 -- <li>If the name is significantly different from the POSIX-function, the
 -- underlying function(s) are stated in the documentation.</li>
 -- <li>Parameters should reflect those of the C-API, buffer length arguments and 
--- by-reference parameters should be ommitted for pratical purposes.</li>
+-- by-reference parameters should be omitted for practical purposes.</li>
 -- <li>If a C function accepts a bitfield as parameter, it should be translated
 -- into lower case string flags representing the flags if the bitfield is the 
--- last parameter and also ommiting prefixes or suffixes. (e.g.  waitpid
+-- last parameter and also omitting prefixes or suffixes. (e.g.  waitpid
 -- (pid, &s, WNOHANG | WUNTRACED) -> waitpid(pid, "nohang", "untraced"), 
 -- getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) ->
 -- Socket:getopt("socket", "reuseaddr"), etc.) </li>

--- a/libs/luci-lib-nixio/docsrc/nixio.Socket.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.Socket.lua
@@ -71,7 +71,7 @@ module "nixio.Socket"
 
 --- Send a message on the socket.
 -- This function is identical to sendto except for the missing destination
--- paramters. See the sendto description for a detailed description.
+-- parameters. See the sendto description for a detailed description.
 -- @class function
 -- @name Socket.send
 -- @param buffer	Buffer holding the data to be written.

--- a/libs/luci-lib-nixio/docsrc/nixio.UnifiedIO.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.UnifiedIO.lua
@@ -24,15 +24,15 @@ module "nixio.UnifiedIO"
 -- @class function
 -- @name UnifiedIO.readall
 -- @usage This function uses the low-level read function of the descriptor.
--- @usage If the length parameter is ommited, this function returns all data
+-- @usage If the length parameter is omitted, this function returns all data
 -- that can be read before an end-of-file, end-of-stream, connection shutdown
 -- or similar happens.
 -- @usage If the descriptor is non-blocking this function may fail with EAGAIN.
 -- @param	length	Bytes to read (optional)
--- @return	data that was successfully read if no error occured
+-- @return	data that was successfully read if no error occurred
 -- @return	- reserved for error code -
 -- @return	- reserved for error message -
--- @return  data that was successfully read even if an error occured
+-- @return  data that was successfully read even if an error occurred
 
 --- Write a block of data and wait until all data is written.
 -- @class function
@@ -40,10 +40,10 @@ module "nixio.UnifiedIO"
 -- @usage This function uses the low-level write function of the descriptor.
 -- @usage If the descriptor is non-blocking this function may fail with EAGAIN.
 -- @param	block	Bytes to write
--- @return	bytes that were successfully written if no error occured
+-- @return	bytes that were successfully written if no error occurred
 -- @return	- reserved for error code -
 -- @return	- reserved for error message -
--- @return  bytes that were successfully written even if an error occured
+-- @return  bytes that were successfully written even if an error occurred
 
 --- Create a line-based iterator.
 -- Lines may end with either \n or \r\n, these control chars are not included
@@ -56,7 +56,7 @@ module "nixio.UnifiedIO"
 -- to stop reading line-based and want to use the read(all) functions instead
 -- you can pass "true" to the iterator which will flush the buffer 
 -- and return the bufferd data.
--- @usage If the limit parameter is ommited, this function uses the nixio
+-- @usage If the limit parameter is omitted, this function uses the nixio
 -- buffersize (8192B by default).
 -- @usage If the descriptor is non-blocking the iterator may fail with EAGAIN.
 -- @usage The iterator can be used as an LTN12 source.
@@ -69,7 +69,7 @@ module "nixio.UnifiedIO"
 -- @usage This function uses the low-level read function of the descriptor.
 -- @usage The blocksize given is only advisory and to be seen as an upper limit,
 -- if an underlying read returns less bytes the chunk is nevertheless returned.
--- @usage If the limit parameter is ommited, the iterator returns data
+-- @usage If the limit parameter is omitted, the iterator returns data
 -- until an end-of-file, end-of-stream, connection shutdown or similar happens.
 -- @usage The iterator will not buffer so it is safe to mix with calls to read.
 -- @usage If the descriptor is non-blocking the iterator may fail with EAGAIN.
@@ -94,15 +94,15 @@ module "nixio.UnifiedIO"
 -- @name UnifiedIO.copy
 -- @usage This function uses the blocksource function of the source descriptor
 -- and the sink function of the target descriptor.
--- @usage If the limit parameter is ommited, data is copied
+-- @usage If the limit parameter is omitted, data is copied
 -- until an end-of-file, end-of-stream, connection shutdown or similar happens.
 -- @usage If the descriptor is non-blocking the function may fail with EAGAIN.
 -- @param	fdout Target Descriptor
 -- @param	size  Bytes to copy (optional)
--- @return	bytes that were successfully written if no error occured
+-- @return	bytes that were successfully written if no error occurred
 -- @return	- reserved for error code -
 -- @return	- reserved for error message -
--- @return  bytes that were successfully written even if an error occured
+-- @return  bytes that were successfully written even if an error occurred
 
 --- Copy data from the current descriptor to another one using kernel-space
 -- copying if possible.
@@ -111,15 +111,15 @@ module "nixio.UnifiedIO"
 -- @usage This function uses the sendfile() syscall to copy the data or the
 -- blocksource function of the source descriptor and the sink function
 -- of the target descriptor as a fallback mechanism.
--- @usage If the limit parameter is ommited, data is copied
+-- @usage If the limit parameter is omitted, data is copied
 -- until an end-of-file, end-of-stream, connection shutdown or similar happens.
 -- @usage If the descriptor is non-blocking the function may fail with EAGAIN.
 -- @param	fdout Target Descriptor
 -- @param	size  Bytes to copy (optional)
--- @return	bytes that were successfully written if no error occured
+-- @return	bytes that were successfully written if no error occurred
 -- @return	- reserved for error code -
 -- @return	- reserved for error message -
--- @return  bytes that were successfully written even if an error occured
+-- @return  bytes that were successfully written even if an error occurred
 
 --- Close the descriptor.
 -- @class function

--- a/libs/luci-lib-nixio/docsrc/nixio.bin.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.bin.lua
@@ -29,5 +29,5 @@ module "nixio.bin"
 --- Base64 decode a given buffer.
 -- @class function
 -- @name b64decode
--- @param buffer	Base 64 Encoded data
+-- @param buffer	Base64 Encoded data
 -- @return binary data

--- a/libs/luci-lib-nixio/docsrc/nixio.fs.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.fs.lua
@@ -47,7 +47,7 @@ module "nixio.fs"
 -- @name nixio.fs.rename
 -- @param	src	Source path
 -- @param 	dest Destination path
--- @usage	It is normally not possible to rename files accross fileystems.
+-- @usage	It is normally not possible to rename files across filesystems.
 -- @return	true
 
 --- Remove an empty directory.

--- a/libs/luci-lib-nixio/docsrc/nixio.lua
+++ b/libs/luci-lib-nixio/docsrc/nixio.lua
@@ -59,7 +59,7 @@ module "nixio"
 -- <li>aliases = Table of alias names</li>
 -- </ul>
 
---- Get all or a specifc proto entry.
+--- Get all or a specific proto entry.
 -- @class function
 -- @name nixio.getproto
 -- @param proto		protocol number or name to lookup (optional)
@@ -118,7 +118,7 @@ module "nixio"
 -- @param flag1 First Flag ["append", "creat", "excl", "nonblock", "ndelay",
 -- "sync", "trunc", "rdonly", "wronly", "rdwr"]
 -- @param ...	More Flags [-"-]
--- @return flag to be used as second paramter to open
+-- @return flag to be used as second parameter to open
 
 --- Duplicate a file descriptor.
 -- @class function
@@ -167,7 +167,7 @@ module "nixio"
 
 --- Wait for some event on a file descriptor.
 -- poll() sets the revents-field of the tables provided by fds to a bitfield
--- indicating the events that occured.
+-- indicating the events that occurred.
 -- @class function
 -- @usage This function works in-place on the provided table and only
 -- writes the revents field, you can use other fields on your demand.
@@ -303,7 +303,7 @@ module "nixio"
 --- Set or unset a environment variable.
 -- @class function
 -- @name nixio.setenv
--- @usage The environment variable will be unset if value is ommited.
+-- @usage The environment variable will be unset if value is omitted.
 -- @param variable	Variable
 -- @param value		Value (optional)
 -- @return true

--- a/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
+++ b/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
@@ -1,15 +1,26 @@
 add_luci_conffiles()
 {
+	add_luci_conffiles_helper()
+	{
+		[ ! -f "$1" ] && return
+		grep -q "$1" "$2" && return
+		echo "$1" >> "$2"
+	}
+
 	local filelist="$1"
 
 	# save ssl certs
 	if [ -d /etc/nixio ]; then
-		find /etc/nixio -type f >> $filelist
+		find /etc/nixio -type f | while read ff; do
+			add_luci_conffiles_helper "$ff" "$filelist"
+		done
 	fi
 
 	# save uhttpd certs
-	[ -f "/etc/uhttpd.key" ] && echo /etc/uhttpd.key >> $filelist
-	[ -f "/etc/uhttpd.crt" ] && echo /etc/uhttpd.crt >> $filelist
+	add_luci_conffiles_helper /etc/uhttpd.key "$filelist"
+	add_luci_conffiles_helper /etc/uhttpd.crt "$filelist"
+
+	unset -f add_luci_conffiles_helper
 }
 
 sysupgrade_init_conffiles="$sysupgrade_init_conffiles add_luci_conffiles"

--- a/libs/luci-lib-nixio/src/Makefile
+++ b/libs/luci-lib-nixio/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(OS),SunOS)
 endif
 
 ifneq (,$(findstring MINGW,$(OS))$(findstring mingw,$(OS))$(findstring Windows,$(OS)))
-	NIXIO_CROSS_CC:=$(shell which i586-mingw32msvc-cc)
+	NIXIO_CROSS_CC:=$(shell command -v i586-mingw32msvc-cc)
 ifneq (,$(NIXIO_CROSS_CC))
 	CC:=$(NIXIO_CROSS_CC)
 endif
@@ -66,7 +66,7 @@ endif
 
 
 %.o: %.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) -c -o $@ $< 
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) -c -o $@ $<
 
 ifneq ($(NIXIO_TLS),)
 tls-crypto.o: $(TLS_DEPENDS) tls-crypto.c
@@ -74,18 +74,18 @@ tls-crypto.o: $(TLS_DEPENDS) tls-crypto.c
 
 tls-context.o: $(TLS_DEPENDS) tls-context.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ tls-context.c
-	
+
 tls-socket.o: $(TLS_DEPENDS) tls-socket.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ tls-socket.c
-	
+
 axtls-compat.o: libaxtls.a axtls-compat.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(NIXIO_CFLAGS) $(LUA_CFLAGS) $(FPIC) $(TLS_CFLAGS) -c -o $@ axtls-compat.c
 	mkdir -p dist
 	cp -pR axtls-root/* dist/
-endif	
+endif
 
 compile: $(NIXIO_OBJ)
-	$(CC) $(LDFLAGS) $(SHLIB_FLAGS) -o $(NIXIO_SO) $(NIXIO_OBJ) $(NIXIO_LDFLAGS) $(NIXIO_LDFLAGS_POST)
+	$(CC) $(LDFLAGS) $(SHLIB_FLAGS) -o $(NIXIO_SO) $(NIXIO_OBJ) $(NIXIO_LDFLAGS) $(NIXIO_LDFLAGS_POST) $(FPIC)
 	mkdir -p dist/usr/lib/lua
 	cp $(NIXIO_SO) dist/usr/lib/lua/$(NIXIO_SO)
 

--- a/libs/luci-lib-nixio/src/address.c
+++ b/libs/luci-lib-nixio/src/address.c
@@ -24,6 +24,7 @@
 
 #ifdef __linux__
 
+#include <sys/time.h>
 #include <signal.h>
 #include <setjmp.h>
 #include <unistd.h>
@@ -289,6 +290,7 @@ static int nixio_getnameinfo(lua_State *L) {
 #ifdef __linux__
 	struct sigaction sa_new, sa_old;
 	int timeout = luaL_optnumber(L, 3, 0);
+	const struct itimerval t = { {timeout * 1000 * 1000, 0} , {0, 0} };
 	if (timeout > 0 && timeout < 1000)
 	{
 		sa_new.sa_handler = nixio__handle_alarm;
@@ -308,7 +310,7 @@ static int nixio_getnameinfo(lua_State *L) {
 			return 3;
 		}
 
-		ualarm(timeout * 1000, 0);
+		setitimer(ITIMER_REAL, &t, NULL);
 	}
 #endif
 
@@ -339,7 +341,7 @@ static int nixio_getnameinfo(lua_State *L) {
 #ifdef __linux__
 	if (timeout > 0 && timeout < 1000)
 	{
-		ualarm(0, 0);
+		alarm(0);
 		sigaction(SIGALRM, &sa_old, NULL);
 	}
 #endif
@@ -542,7 +544,7 @@ static int nixio_getifaddrs(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #if defined(__linux__) || defined(BSD)
 	{"getifaddrs",	nixio_getifaddrs},
 #endif
@@ -552,7 +554,7 @@ static const luaL_reg R[] = {
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"getsockname",	nixio_sock_getsockname},
 	{"getpeername",	nixio_sock_getpeername},
 	{NULL,			NULL}

--- a/libs/luci-lib-nixio/src/binary.c
+++ b/libs/luci-lib-nixio/src/binary.c
@@ -292,7 +292,7 @@ static int nixio_bin_b64decode(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"hexlify",		nixio_bin_hexlify},
 	{"unhexlify",	nixio_bin_unhexlify},
 	{"crc32",		nixio_bin_crc32},

--- a/libs/luci-lib-nixio/src/bind.c
+++ b/libs/luci-lib-nixio/src/bind.c
@@ -269,14 +269,14 @@ static int nixio_sock_accept(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"bind",		nixio_bind},
 	{"connect",		nixio_connect},
 	{NULL,			NULL}
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"bind",		nixio_sock_bind},
 	{"connect",		nixio_sock_connect},
 	{"listen",		nixio_sock_listen},

--- a/libs/luci-lib-nixio/src/bit.c
+++ b/libs/luci-lib-nixio/src/bit.c
@@ -120,7 +120,7 @@ static int nixio_bit_swap(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"bor",			nixio_bit_or},
 	{"set",			nixio_bit_or},
 	{"band",		nixio_bit_and},

--- a/libs/luci-lib-nixio/src/file.c
+++ b/libs/luci-lib-nixio/src/file.c
@@ -379,7 +379,7 @@ static int nixio_file__tostring(lua_State *L) {
 }
 
 /* method table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"write",		nixio_file_write},
 	{"read",		nixio_file_read},
 	{"tell",		nixio_file_tell},
@@ -394,7 +394,7 @@ static const luaL_reg M[] = {
 };
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"dup",			nixio_dup},
 	{"open",		nixio_open},
 	{"open_flags",	nixio_open_flags},

--- a/libs/luci-lib-nixio/src/fs.c
+++ b/libs/luci-lib-nixio/src/fs.c
@@ -519,7 +519,7 @@ static int nixio_statvfs(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifndef __WINNT__
 	{"glob",		nixio_glob},
 	{"mkfifo",		nixio_mkfifo},

--- a/libs/luci-lib-nixio/src/io.c
+++ b/libs/luci-lib-nixio/src/io.c
@@ -208,7 +208,7 @@ static int nixio_sock_recvfrom(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"send",	nixio_sock_send},
 	{"sendto",	nixio_sock_sendto},
 	{"recv",	nixio_sock_recv},

--- a/libs/luci-lib-nixio/src/nixio.c
+++ b/libs/luci-lib-nixio/src/nixio.c
@@ -102,7 +102,7 @@ static int nixio_strerror(lua_State *L) {
 }
 
 /* object table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"errno",		nixio_errno},
 	{"strerror",	nixio_strerror},
 	{NULL,			NULL}

--- a/libs/luci-lib-nixio/src/nixio.h
+++ b/libs/luci-lib-nixio/src/nixio.h
@@ -21,6 +21,10 @@
 #include <lauxlib.h>
 #include <luaconf.h>
 
+#if LUA_VERSION_NUM < 501
+#define luaL_Reg luaL_reg
+#endif
+
 #define NIXIO_BUFFERSIZE 8192
 
 typedef struct nixio_socket {

--- a/libs/luci-lib-nixio/src/poll.c
+++ b/libs/luci-lib-nixio/src/poll.c
@@ -197,7 +197,7 @@ static int nixio_poll(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"gettimeofday", nixio_gettimeofday},
 	{"nanosleep",	nixio_nanosleep},
 	{"poll",		nixio_poll},

--- a/libs/luci-lib-nixio/src/process.c
+++ b/libs/luci-lib-nixio/src/process.c
@@ -412,7 +412,7 @@ static int nixio_sysinfo(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifdef __linux__
 	{"sysinfo",		nixio_sysinfo},
 #endif

--- a/libs/luci-lib-nixio/src/protoent.c
+++ b/libs/luci-lib-nixio/src/protoent.c
@@ -91,7 +91,7 @@ static int nixio_getproto(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
     {"getprotobyname",		nixio_getprotobyname},
     {"getprotobynumber",	nixio_getprotobynumber},
     {"getproto",			nixio_getproto},

--- a/libs/luci-lib-nixio/src/socket.c
+++ b/libs/luci-lib-nixio/src/socket.c
@@ -150,13 +150,13 @@ static int nixio_sock_shutdown(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"socket",		nixio_socket},
 	{NULL,			NULL}
 };
 
 /* object table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"close",		nixio_sock_close},
 	{"shutdown",	nixio_sock_shutdown},
 	{"__gc",		nixio_sock__gc},

--- a/libs/luci-lib-nixio/src/sockopt.c
+++ b/libs/luci-lib-nixio/src/sockopt.c
@@ -366,7 +366,7 @@ static int nixio_sock_setsockopt(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"setblocking", nixio_sock_setblocking},
 	{"getsockopt",	nixio_sock_getsockopt},
 	{"setsockopt",	nixio_sock_setsockopt},

--- a/libs/luci-lib-nixio/src/splice.c
+++ b/libs/luci-lib-nixio/src/splice.c
@@ -161,7 +161,7 @@ static int nixio_sendfile(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 #ifdef _GNU_SOURCE
 #ifdef SPLICE_F_MOVE
 	{"splice",			nixio_splice},

--- a/libs/luci-lib-nixio/src/syslog.c
+++ b/libs/luci-lib-nixio/src/syslog.c
@@ -102,7 +102,7 @@ static int nixio_syslog(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"openlog",		nixio_openlog},
 	{"syslog",		nixio_syslog},
 	{"setlogmask",	nixio_setlogmask},

--- a/libs/luci-lib-nixio/src/tls-context.c
+++ b/libs/luci-lib-nixio/src/tls-context.c
@@ -203,13 +203,13 @@ static int nixio_tls_ctx__tostring(lua_State *L) {
 }
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"tls",		nixio_tls_ctx},
 	{NULL,			NULL}
 };
 
 /* ctx function table */
-static const luaL_reg CTX_M[] = {
+static const luaL_Reg CTX_M[] = {
 	{"set_cert",			nixio_tls_ctx_set_cert},
 	{"set_verify_locations",       nixio_tls_ctx_set_verify_locations},
 	{"set_key",				nixio_tls_ctx_set_key},

--- a/libs/luci-lib-nixio/src/tls-crypto.c
+++ b/libs/luci-lib-nixio/src/tls-crypto.c
@@ -154,14 +154,14 @@ static int nixio_crypto_hash__tostring(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"hash",		nixio_crypto_hash},
 	{"hmac",		nixio_crypto_hmac},
 	{NULL,			NULL}
 };
 
 /* hash table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"update",		nixio_crypto_hash_update},
 	{"final",		nixio_crypto_hash_final},
 	{"__gc",		nixio_crypto_hash__gc},

--- a/libs/luci-lib-nixio/src/tls-socket.c
+++ b/libs/luci-lib-nixio/src/tls-socket.c
@@ -239,7 +239,7 @@ static int nixio_tls_sock__tostring(lua_State *L) {
 
 
 /* ctx function table */
-static const luaL_reg M[] = {
+static const luaL_Reg M[] = {
 	{"recv", 		nixio_tls_sock_recv},
 	{"send", 		nixio_tls_sock_send},
 	{"read", 		nixio_tls_sock_recv},

--- a/libs/luci-lib-nixio/src/user.c
+++ b/libs/luci-lib-nixio/src/user.c
@@ -238,7 +238,7 @@ static int nixio_crypt(lua_State *L) {
 
 
 /* module table */
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 	{"crypt",		nixio_crypt},
 	{"getgr",		nixio_getgr},
 	{"getpw",		nixio_getpw},
@@ -252,7 +252,7 @@ static const luaL_reg R[] = {
 
 #else /* __WINNT__ */
 
-static const luaL_reg R[] = {
+static const luaL_Reg R[] = {
 		{NULL,			NULL}
 };
 


### PR DESCRIPTION
## luci-lib-nixio

###  [01] Always build without TLS support

- The build system fails to set up the chosen TLS provider and always builds the package without TLS.

- While this could be easily fixed, the package would fail to build with axTLS and cyaSSL without further intervention.

- The version of axTLS included with the source is outdated, as is the API used with cyaSSL, now wolfSSL.

- OpenSSL support could be enabled, but the TLS code limits connections to TLS 1.0, deprecated by RFC 8996: "TLS 1.0 MUST NOT be used".

- Remove the provider configuration from build options, and always build the library without TLS.

### [02] Sync source code from [openwrt-24.10](/openwrt/luci/tree/openwrt-24.10/libs/luci-lib-nixio)

## References

[luci-lib-nixio: always build without TLS support](/openwrt/luci/commit/88b9088514700a90c1fc5855cedf004db1ad04e3)