### PR TITLE
luci-theme-design: Fixed an issue where some input boxes were too small to read when the horizontal resolution exceeded 1280

### DIFF
--- a/themes/luci-theme-design/htdocs/luci-static/design/css/cascade.css
+++ b/themes/luci-theme-design/htdocs/luci-static/design/css/cascade.css
@@ -2546,6 +2546,9 @@ td>table>tbody>tr>td,
   width: auto
 }
 
+.cbi-section-table-row>.cbi-value-field{
+	min-width: 10rem
+}
 /* progressbar */
 .cbi-progressbar {
   position: relative;


### PR DESCRIPTION
修复当横向分辨率超过1280时一些内容输入框过小导致无法看清内容的问题

一些软件比如samba4，由于横向输入框过多，导致横向分辨率大于1280下输入框显示很窄，造成内容无法输入

所以修改了下样式，在分辨率大于1280的情况下，将输入框的宽度固定为10rem
横向分辨率小于1280时界面显示正常。

修改前：
![2](https://github.com/user-attachments/assets/548c027a-02b7-4032-8160-7f91eeeb4e0c)
修改后：
![3](https://github.com/user-attachments/assets/09c726f0-5053-4b17-82ae-0572a2a2db2a)
