### PR TITLE
luci-app-dockerman: fix unhandled nil on containers page

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/containers.lua
@@ -75,7 +75,9 @@ function get_containers()
 			local ip = require "luci.ip"
 			for _,v2 in ipairs(v.Ports) do
 				-- display ipv4 only
-				if ip.new(v2.IP or "0.0.0.0"):is4() then
+				local ip_str = v2.IP or "0.0.0.0"
+				local success, ip_obj = pcall(ip.new, ip_str or "0.0.0.0")
+				if success and ip_obj and ip_obj:is4() then
 					data[index]["_ports"] = (data[index]["_ports"] and (data[index]["_ports"] .. ", ") or "")
 					.. ((v2.PublicPort and v2.Type and v2.Type == "tcp") and ('<a href="javascript:void(0);" onclick="window.open((window.location.origin.match(/^(.+):\\d+$/) && window.location.origin.match(/^(.+):\\d+$/)[1] || window.location.origin) + \':\' + '.. v2.PublicPort ..', \'_blank\');">') or "")
 					.. (v2.PublicPort and (v2.PublicPort .. ":") or "")  .. (v2.PrivatePort and (v2.PrivatePort .."/") or "") .. (v2.Type and v2.Type or "")


### PR DESCRIPTION
fixed luci-app-dockerman on docker version 29.1.1 bugs for unhandled nil on containers page
<img width="945" height="231" alt="image" src="https://github.com/user-attachments/assets/963c5a82-88c4-4a25-9ca5-aa5d15174567" />

https://github.com/coolsnowwolf/luci/issues/379

<img width="1604" height="719" alt="image" src="https://github.com/user-attachments/assets/96db7451-5ca6-496d-aa75-f9ffec0b60d1" />
