### PR TITLE
luci-mod-admin-full: improve UI style for wifi_join page

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
+++ b/modules/luci-mod-admin-full/luasrc/view/admin_network/wifi_join.htm
@@ -90,12 +90,13 @@
 
 <%+header%>
 
-<h2 name="content"><%:Join Network: Wireless Scan%></h2>
+<h2 name="content"><%:Join Network: Wireless Scan%><span id="wifi_counts"> ...</span><span style="float:right;" title="<%=dev%>"><%=iw.ifname%></span></h2>
 
 <div class="cbi-map">
 	<fieldset class="cbi-section">
 		<table class="cbi-section-table" style="empty-cells:hide">
 			<tr class="cbi-section-table-titles">
+				<th class="cbi-section-table-cell" style="text-align: center;">#</th>
 				<th class="cbi-section-table-cell" style="text-align: center;"><%:Signal%></th>
 				<th class="cbi-section-table-cell">SSID</th>
 				<th class="cbi-section-table-cell" style="text-align: center;"><%:Channel%></th>
@@ -107,8 +108,9 @@
 			<!-- scan list -->
 			<% for i, net in ipairs(scanlist(1)) do net.encryption = net.encryption or { } %>
 			<tr class="cbi-section-table-row cbi-rowstyle-<%=1 + ((i-1) % 2)%>">
+				<td class="cbi-value-field" style="vertical-align: middle; text-align: center;"><%=i%></td>
 				<td class="cbi-value-field" style="vertical-align: middle; text-align: center; padding: 5px 10px 5px;">
-					<span title="<%=percent_wifi_signal(net)%>%" class="ifacebadge" style="padding: 2px 5px; background-image: none; background-color: transparent;"><img src="<%=guess_wifi_signal(net)%>"><span style="margin-left: 6px;"><%=net.signal%> dBm</span></span>
+					<span title="<%=percent_wifi_signal(net)%>%" class="ifacebadge" style="padding: 2px 5px;"><img src="<%=guess_wifi_signal(net)%>"><span style="margin-left: 6px;"><%=net.signal%> dBm</span></span>
 				</td>
 				<td class="cbi-value-field" style="vertical-align: middle; padding: 5px 10px 5px;"><%=net.ssid and utl.pcdata(net.ssid) or "<em>%s</em>" % translate("hidden")%></td>
 				<td class="cbi-value-field" style="vertical-align: middle; text-align: center; padding: 5px 10px 5px;"><%=net.channel%></td>
@@ -152,5 +154,9 @@
 		<input class="cbi-button cbi-input-find" type="submit" value="<%:Repeat scan%>" />
 	</form>
 </div>
+
+<script type="text/javascript">//<![CDATA[
+	document.querySelector("#wifi_counts").innerText = "(" + document.querySelectorAll("tr.cbi-section-table-row").length + ")";
+//]]></script>
 
 <%+footer%>


### PR DESCRIPTION
### 优化 WiFi 扫描结果页展示样式

* 新增扫描出来的 WiFi 数量显示

* 显示当前无线网卡的名称

* 信号栏样式兼容其他主题

<img width="964" height="715" alt="WiFi_Scan_List_UI" title="WiFi_Scan_List_UI" src="https://github.com/user-attachments/assets/dc5c99d5-680b-4795-bf27-9755d2edfc0a" />

> 主打一个缝缝补补又三年！