### PR TITLE
luci-app-turboacc: fix Broadcom spelling

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -68,7 +68,7 @@ return view.extend({
 			o = s.option(form.ListValue, 'fullcone', _('Enable FullCone NAT'));
 			o.value('0', _('Disable'));
 			o.value('1', _('FULLCONENAT'));
-			o.value('2', _('Boardcom Fullcone NAT1'));
+			o.value('2', _('Broadcom Fullcone NAT1'));
 			addTCPCCAOption();
 			if (fw4)
 				o = s.option(form.Flag, 'fullcone6', _('Enable FullCone NAT6'));

--- a/applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js
+++ b/applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js
@@ -194,7 +194,7 @@ return view.extend({
 		o.value('0', _('Disable'))
 		if (features.hasXTFULLCONENAT || features.hasNFTFULLCONENAT) {
 			o.value('1', _('FULLCONENAT'));
-			o.value('2', _('Boardcom Fullcone NAT1'));
+			o.value('2', _('Broadcom Fullcone NAT1'));
 		}
 		o.default = '0';
 		o.rmempty = false;

--- a/applications/luci-app-turboacc/po/templates/turboacc.pot
+++ b/applications/luci-app-turboacc/po/templates/turboacc.pot
@@ -5,8 +5,8 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "Acceleration Status"
 msgstr ""
 
-#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:182
-msgid "Boardcom fullcone"
+#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:197
+msgid "Broadcom Fullcone NAT1"
 msgstr ""
 
 #: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:151

--- a/applications/luci-app-turboacc/po/zh_Hans/turboacc.po
+++ b/applications/luci-app-turboacc/po/zh_Hans/turboacc.po
@@ -12,10 +12,6 @@ msgstr ""
 msgid "Acceleration Status"
 msgstr "加速状态"
 
-#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:182
-msgid "Boardcom fullcone"
-msgstr "Boardcom fullcone"
-
 #: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:151
 msgid "Bridge Acceleration"
 msgstr "桥接加速"
@@ -93,9 +89,9 @@ msgstr "全锥形 NAT1"
 msgid "FULLCONENAT"
 msgstr "兼容模式全锥形 NAT1"
 
-#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:177
-msgid "Boardcom Fullcone NAT1"
-msgstr "高性能 Boardcom 全锥形 NAT1"
+#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:197
+msgid "Broadcom Fullcone NAT1"
+msgstr "高性能 Broadcom 全锥形 NAT1"
 
 #: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:178
 msgid "Full cone NAT (NAT1) can improve gaming performance effectively."
@@ -175,7 +171,3 @@ msgstr "Turbo ACC 网络加速设置"
 #: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:181
 msgid "xt_FULLCONENAT"
 msgstr "兼容模式"
-
-#: applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js:182
-msgid "Boardcom fullcone"
-msgstr "高性能模式"

--- a/applications/luci-app-turboacc/root/usr/libexec/rpcd/luci.turboacc
+++ b/applications/luci-app-turboacc/root/usr/libexec/rpcd/luci.turboacc
@@ -104,9 +104,9 @@ local methods = {
 			(readfile("/sys/module/nft_fullcone/refcnt") or "0") ~= "0" then
 				fctype = "nft_FULLCONENAT"
 			elseif sys.call("nft list ruleset 2>/dev/null | grep -q 'masquerade fullcone'") == 0 then
-				fctype = "Boardcom Fullcone NAT1"
+				fctype = "Broadcom Fullcone NAT1"
 			elseif sys.call("iptables -t nat -L zone_wan_postrouting 2>/dev/null | grep -q fullcone") == 0 then
-				fctype = "Boardcom Fullcone NAT1"
+				fctype = "Broadcom Fullcone NAT1"
 			end
 			print(json.stringify({ type = fctype }))
 		end


### PR DESCRIPTION
The Broadcom fullcone implementation uses the BCM naming throughout the kernel and firewall integration. Correct the misspelled `Boardcom` user-facing labels and status strings to `Broadcom`.

The underlying UCI option values and fullcone detection logic are unchanged.

Update the TurboACC translation template and Simplified Chinese catalog to keep the corrected msgid translated. Remove two stale duplicate `Boardcom fullcone` entries that caused `msgfmt` validation to fail.

Tested:
- `npx eslint applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js applications/luci-app-turboacc/htdocs/luci-static/resources/view/turboacc.js`
- `node --check` on both changed JavaScript files
- `msgfmt --check --check-compatibility` on the Simplified Chinese catalog
- `./build/i18n-scan.pl` for both affected applications
- `git diff --check`
- Verified no `Boardcom` references remain in either affected application