### PR TITLE
update luci-app-sysctl  1.7.6

### DIFF
--- a/applications/luci-app-sysctl/Makefile
+++ b/applications/luci-app-sysctl/Makefile
@@ -13,7 +13,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-sysctl
-PKG_VERSION:=1.7.1
+PKG_VERSION:=1.7.4
 PKG_RELEASE:=1
 
 PKG_LICENSE:=Apache-2.0

--- a/applications/luci-app-sysctl/Makefile
+++ b/applications/luci-app-sysctl/Makefile
@@ -13,7 +13,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-sysctl
-PKG_VERSION:=1.5.9
+PKG_VERSION:=1.7.1
 PKG_RELEASE:=1
 
 PKG_LICENSE:=Apache-2.0

--- a/applications/luci-app-sysctl/Makefile
+++ b/applications/luci-app-sysctl/Makefile
@@ -13,7 +13,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-sysctl
-PKG_VERSION:=1.7.4
+PKG_VERSION:=1.7.6
 PKG_RELEASE:=1
 
 PKG_LICENSE:=Apache-2.0
@@ -25,8 +25,11 @@ LUCI_DESCRIPTION:=View live kernel parameters and manage custom sysctl entries \
  Supports browsing /proc/sys, searching parameters, one-click apply and \
  immediate runtime activation of single parameters.
 LUCI_DEPENDS:=+luci-base +rpcd +rpcd-mod-ucode
-LUCI_CONFFILES:=/etc/sysctl.d/99-luci-sysctl.conf
 LUCI_PKGARCH:=all
+
+define Package/luci-app-sysctl/conffiles
+/etc/sysctl.d/99-luci-sysctl.conf
+endef
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
+++ b/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
@@ -208,12 +208,12 @@ return view.extend({
 		return E('div', { 'class': 'cbi-section' }, [
 			E('h3', {}, _('自定义参数')),
 			E('div', { 'class': 'cbi-section-descr' }, descr),
+			this.applyResultBox,
 			this.editFormBox,
 			this.tableWrapBox,
 			this.customEmptyBox,
 			this.fileViewBox,
 			this.dupBox,
-			this.applyResultBox,
 			E('div', { 'class': 'cbi-page-actions' }, [
 				E('button', {
 					'class': 'cbi-button cbi-button-add',
@@ -572,14 +572,16 @@ return view.extend({
 			else if (applyNow && res.applied === false)
 				notes.push(E('p', { 'style': 'color:#a80' }, _('参数 %s 已写入配置，但运行时校验不一致，请检查取值格式。').format(key)));
 
+			var hasWarn = (res.rename_leftover != null) || (!res.exists) || (applyNow && (res.applied === 'readonly' || res.applied === false));
+			var saveAutoHide = hasWarn ? 8000 : 4000;
+
 			if (notes.length == 0)
 				notes.push(E('p', {}, (st.fromMain && isNew) ? _('已创建覆盖条目：%s。') : _('参数 %s 已保存。').format(key)));
 
 			self.hideEditForm();
 			self.reloadList();
 
-			dom.content(self.applyResultBox, [ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ]);
-			self.applyResultBox.style.display = '';
+			self.showApplyResult([ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ], saveAutoHide);
 
 			/* post-save heads-up: same key also defined in other files? */
 			callDupCheck(key).then(function(dres) {
@@ -597,8 +599,8 @@ return view.extend({
 					? _('注意：该参数在自定义配置之后加载的文件中也有定义（%s），你的取值会被覆盖。').format(sum.others.join('、'))
 					: _('该参数在其他文件中也有定义（%s），自定义配置加载靠后，以你的值为准。').format(sum.others.join('、'));
 
-				notes.push(E('p', { 'style': 'color:' + (sum.shadowed ? '#b3261e' : '#a35a00') }, msg));
-				dom.content(self.applyResultBox, [ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ]);
+					notes.push(E('p', { 'style': 'color:' + (sum.shadowed ? '#b3261e' : '#a35a00') }, msg));
+				self.showApplyResult([ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ], 8000);
 			}).catch(function() {});
 		}).catch(function(e) {
 			errBox.textContent = '';
@@ -696,11 +698,44 @@ return view.extend({
 		});
 	},
 
+	/* Unified result-bar display: shows nodes, optional auto-hide after
+	 * autoHideMs (0 = stay until replaced). Re-calling resets the timer. */
+	showApplyResult: function(nodes, autoHideMs) {
+		if (this.applyResultTimer != null) {
+			window.clearTimeout(this.applyResultTimer);
+			this.applyResultTimer = null;
+		}
+
+		dom.content(this.applyResultBox, nodes);
+		this.applyResultBox.style.display = '';
+
+		if (autoHideMs > 0) {
+			var box = this.applyResultBox;
+
+			this.applyResultTimer = window.setTimeout(function() {
+				box.style.display = 'none';
+				dom.content(box, []);
+			}, autoHideMs);
+		}
+	},
+
+	hideApplyResult: function() {
+		if (this.applyResultTimer != null) {
+			window.clearTimeout(this.applyResultTimer);
+			this.applyResultTimer = null;
+		}
+
+		this.applyResultBox.style.display = 'none';
+		dom.content(this.applyResultBox, []);
+	},
+
 	applyConfig: function() {
 		var self = this;
 
-		dom.content(this.applyResultBox, [ E('p', { 'style': 'color:#777;padding:6px' }, _('正在应用全部配置，请稍候…')) ]);
-		this.applyResultBox.style.display = '';
+		this.showApplyResult([ E('p', { 'style': 'color:#777;padding:6px' }, _('正在应用全部配置，请稍候…')) ], 0);
+
+		if (this.applyResultBox.scrollIntoView)
+			this.applyResultBox.scrollIntoView({ block: 'nearest' });
 
 		return callApply().then(function(res) {
 			var errors = (res != null && res.errors != null) ? res.errors : [];
@@ -711,7 +746,8 @@ return view.extend({
 			}
 			else if (errors.length == 0) {
 				content = E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, [
-					E('p', {}, _('全部配置已成功应用。'))
+					E('p', {}, _('全部配置已成功应用。')),
+					E('p', { 'style': 'color:#777;font-size:12px;margin:2px 0 0' }, _('（本提示将在数秒后自动消失）'))
 				]);
 			}
 			else {
@@ -751,10 +787,14 @@ return view.extend({
 				]);
 			}
 
-			dom.content(self.applyResultBox, [ content ]);
+			self.showApplyResult([ content ], (res != null && res.code == 0 && errors.length == 0) ? 4000 : 0);
+
+			if (self.applyResultBox.scrollIntoView)
+				self.applyResultBox.scrollIntoView({ block: 'nearest' });
+
 			self.reloadList();
 		}).catch(function(e) {
-			dom.content(self.applyResultBox, [ self.errorBox(_('应用失败：%s').format(e.message), self.backendErrorHint(e.message)) ]);
+			self.showApplyResult([ self.errorBox(_('应用失败：%s').format(e.message), self.backendErrorHint(e.message)) ], 0);
 		});
 	},
 

--- a/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
+++ b/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
@@ -76,7 +76,8 @@ var LSC_CSS = [
 	'.lsc-root .cbi-button:hover { filter: brightness(1.06); }',
 	'.lsc-root h2, .lsc-root h3, .lsc-root h4, .lsc-root th, .lsc-root .lsc-badge, .lsc-root code, .lsc-root .lsc-muted, .lsc-root .cbi-section-descr, .lsc-root .lsc-card * { text-transform: none !important; }',
 	'.lsc-root .lsc-muted { color: #777; }',
-	'.lsc-root .cbi-page-actions { float: none !important; text-align: center !important; }'
+	'.lsc-root .cbi-page-actions { float: none !important; text-align: center !important; display: flex !important; flex-wrap: wrap; justify-content: center !important; align-items: center; gap: .5rem; }',
+	'.lsc-root .cbi-page-actions > br { display: none; }'
 ].join('\n');
 
 return view.extend({
@@ -619,6 +620,12 @@ return view.extend({
 			self.refreshCustomTable();
 			self.refreshPresetStatus();
 			self.refreshSourceChips();
+
+			/* re-render an open file panel so its "当前值" column reflects
+			 * the kernel state AFTER an apply/refresh (values were stale
+			 * otherwise, making applied settings look ineffective) */
+			if (self.fileViewPath != null)
+				self.renderFilePanel();
 		}).catch(function(e) {
 			ui.addNotification(null, E('p', {}, _('加载失败：%s').format(e.message)), 'error');
 		});
@@ -710,14 +717,36 @@ return view.extend({
 			else {
 				var items = [];
 
-				for (var i = 0; i < errors.length; i++)
-					items.push(E('li', {}, [
-						E('strong', {}, errors[i].file),
-						E('pre', { 'style': 'white-space:pre-wrap;margin:4px 0' }, errors[i].output || '')
-					]));
+				for (var i = 0; i < errors.length; i++) {
+					var er = errors[i];
+					var parts = [ E('strong', {}, er.file) ];
+
+					/* real command errors (permission denied etc.) */
+					if (er.output)
+						parts.push(E('pre', { 'style': 'white-space:pre-wrap;margin:4px 0' }, er.output));
+
+					/* kernel did not accept these values (echo was silent,
+					 * but read-back differs) */
+					if (er.not_applied != null && er.not_applied.length > 0) {
+						var naItems = [];
+
+						for (var j = 0; j < er.not_applied.length; j++) {
+							var na = er.not_applied[j];
+
+							naItems.push(E('li', {}, _('%s：写入 %s，内核当前 %s').format(
+								na.key, na.value, na.current)));
+						}
+
+						parts.push(E('p', { 'style': 'margin:4px 0' },
+							_('以下参数内核未接受（可能被限制、随后被覆盖或需要重启生效）：')));
+						parts.push(E('ul', { 'style': 'margin:2px 0' }, naItems));
+					}
+
+					items.push(E('li', {}, parts));
+				}
 
 				content = E('div', { 'class': 'alert-message warning', 'style': 'margin:6px 0' }, [
-					E('p', {}, _('应用完成，以下文件存在报错（常见原因：参数不存在、只读或权限不足）：')),
+					E('p', {}, _('应用完成，以下内容需要留意（常见原因：参数不存在、只读、被内核拒绝或被其他文件覆盖）：')),
 					E('ul', {}, items)
 				]);
 			}

--- a/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
+++ b/applications/luci-app-sysctl/htdocs/luci-static/resources/view/sysctl.js
@@ -40,6 +40,7 @@ var callPresetList = rpc.declare({
 var callFileView = rpc.declare({ object: 'luci.sysctl', method: 'file_view', params: [ 'path' ] });
 var callFileSet = rpc.declare({ object: 'luci.sysctl', method: 'file_set', params: [ 'path', 'key', 'value', 'disabled' ] });
 var callFileDelete = rpc.declare({ object: 'luci.sysctl', method: 'file_delete', params: [ 'path', 'key' ] });
+var callDupCheck = rpc.declare({ object: 'luci.sysctl', method: 'dup_check', params: [ 'key' ] });
 
 var KEY_RE = /^[A-Za-z0-9_][A-Za-z0-9_.\/-]*$/;
 
@@ -179,6 +180,7 @@ return view.extend({
 		}, _('暂无自定义参数，点击下方“添加参数”开始。'));
 		this.editFormBox = E('div', { 'style': 'display:none' });
 		this.fileViewBox = E('div', { 'style': 'display:none' });
+		this.dupBox = E('div', { 'style': 'display:none' });
 		this.applyResultBox = E('div', { 'style': 'display:none' });
 		this.sourceChipsBox = E('div', { 'class': 'lsc-chips' });
 
@@ -209,6 +211,7 @@ return view.extend({
 			this.tableWrapBox,
 			this.customEmptyBox,
 			this.fileViewBox,
+			this.dupBox,
 			this.applyResultBox,
 			E('div', { 'class': 'cbi-page-actions' }, [
 				E('button', {
@@ -220,6 +223,11 @@ return view.extend({
 					'class': 'cbi-button cbi-button-apply',
 					'click': ui.createHandlerFn(this, 'applyConfig')
 				}, _('应用配置')),
+				' ',
+				E('button', {
+					'class': 'cbi-button',
+					'click': ui.createHandlerFn(this, 'showDupCheck')
+				}, _('检测重复')),
 				' ',
 				E('button', {
 					'class': 'cbi-button cbi-button-negative',
@@ -294,7 +302,11 @@ return view.extend({
 	},
 
 	showEditForm: function(entry) {
-		this.editing = (entry != null) ? entry : null;
+		/* "添加参数" button calls this with null -> use a blank new-entry
+		 * state, otherwise renderEditForm would bail out and the form would
+		 * never open (latent bug since v1.0, other entries always passed an
+		 * object so it never surfaced until now). */
+		this.editing = (entry != null) ? entry : { isNew: true };
 		this.editFromBrowse = (entry != null && entry.fromBrowse === true);
 		this.renderEditForm();
 
@@ -350,6 +362,20 @@ return view.extend({
 
 		saveBtn.addEventListener('click', function() { self.saveEditForm(keyInput, valInput, applyChk, disabledChk, errBox); });
 
+		var editDupBox = E('div', { 'style': 'display:none' });
+		this.editDupBox = editDupBox;
+
+		keyInput.addEventListener('input', function() {
+			if (self.editDupTimer != null)
+				window.clearTimeout(self.editDupTimer);
+
+			var v = keyInput.value;
+
+			self.editDupTimer = window.setTimeout(function() {
+				self.refreshEditDup((v || '').trim());
+			}, 400);
+		});
+
 		dom.content(this.editFormBox, [
 			E('div', { 'class': 'lsc-card' }, [
 				E('strong', {}, title),
@@ -369,6 +395,7 @@ return view.extend({
 					])
 				]),
 				E('div', { 'style': 'color:#666;margin-top:4px' }, note),
+				editDupBox,
 				errBox,
 				E('div', { 'style': 'margin-top:8px' }, [
 					saveBtn, ' ',
@@ -376,10 +403,19 @@ return view.extend({
 				])
 			])
 		]);
+
+		if (key != '')
+			this.refreshEditDup(key);
 	},
 
 	hideEditForm: function() {
 		this.editing = null;
+
+		if (this.editDupTimer != null) {
+			window.clearTimeout(this.editDupTimer);
+			this.editDupTimer = null;
+		}
+
 		this.renderEditForm();
 
 		/* edit was started from the browse section: scroll back there so the
@@ -390,6 +426,83 @@ return view.extend({
 			if (this.browseSectionBox != null && this.browseSectionBox.scrollIntoView)
 				this.browseSectionBox.scrollIntoView({ block: 'start' });
 		}
+	},
+
+	/* Summarize where a key is defined besides the custom config, and whether
+	 * any of those files load AFTER the custom config (=> would override it). */
+	summarizeDup: function(d) {
+		var customPath = '/etc/sysctl.d/99-luci-sysctl.conf';
+		var files = (this.statusData != null && this.statusData.files != null) ? this.statusData.files : [];
+		var paths = [];
+		var i;
+
+		for (i = 0; i < files.length; i++)
+			paths.push(files[i].path);
+
+		var customIdx = paths.indexOf(customPath);
+		var others = [];
+		var shadowed = false;
+
+		for (i = 0; i < d.entries.length; i++) {
+			var e = d.entries[i];
+
+			if (e.path == customPath)
+				continue;
+
+			others.push(e.path.replace('/etc/', '') + ' (' + e.value + ')');
+
+			if (!e.disabled && customIdx >= 0 && paths.indexOf(e.path) > customIdx)
+				shadowed = true;
+		}
+
+		return { others: others, shadowed: shadowed };
+	},
+
+	/* Inline warning inside the add/edit form: warn BEFORE saving that the
+	 * key is also defined in other config files (and whether those files
+	 * would override the custom entry). */
+	refreshEditDup: function(key) {
+		var self = this;
+		var box = this.editDupBox;
+
+		if (box == null)
+			return;
+
+		if (key == null || key == '' || !KEY_RE.test(key)) {
+			box.style.display = 'none';
+			dom.content(box, []);
+			return;
+		}
+
+		callDupCheck(key).then(function(res) {
+			var dups = (res != null && res.dups != null) ? res.dups : [];
+
+			if (dups.length == 0 || self.editing == null) {
+				box.style.display = 'none';
+				dom.content(box, []);
+				return;
+			}
+
+			var sum = self.summarizeDup(dups[0]);
+
+			if (sum.others.length == 0) {
+				box.style.display = 'none';
+				dom.content(box, []);
+				return;
+			}
+
+			var msg = sum.shadowed
+				? _('注意：该参数在自定义配置之后加载的文件中也有定义（%s），保存后会被覆盖、不会生效。请直接编辑对应文件或删除其同名条目。').format(sum.others.join('、'))
+				: _('该参数在其他文件中也有定义（%s）。自定义配置加载顺序靠后，保存后以这里的值为准。').format(sum.others.join('、'));
+
+			box.style.display = '';
+			dom.content(box, [
+				E('div', { 'style': (sum.shadowed ? 'color:#b3261e' : 'color:#a35a00') + ';margin-top:4px' }, msg)
+			]);
+		}).catch(function() {
+			box.style.display = 'none';
+			dom.content(box, []);
+		});
 	},
 
 	saveEditForm: function(keyInput, valInput, applyChk, disabledChk, errBox) {
@@ -466,6 +579,26 @@ return view.extend({
 
 			dom.content(self.applyResultBox, [ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ]);
 			self.applyResultBox.style.display = '';
+
+			/* post-save heads-up: same key also defined in other files? */
+			callDupCheck(key).then(function(dres) {
+				var dups = (dres != null && dres.dups != null) ? dres.dups : [];
+
+				if (dups.length == 0)
+					return;
+
+				var sum = self.summarizeDup(dups[0]);
+
+				if (sum.others.length == 0)
+					return;
+
+				var msg = sum.shadowed
+					? _('注意：该参数在自定义配置之后加载的文件中也有定义（%s），你的取值会被覆盖。').format(sum.others.join('、'))
+					: _('该参数在其他文件中也有定义（%s），自定义配置加载靠后，以你的值为准。').format(sum.others.join('、'));
+
+				notes.push(E('p', { 'style': 'color:' + (sum.shadowed ? '#b3261e' : '#a35a00') }, msg));
+				dom.content(self.applyResultBox, [ E('div', { 'class': 'alert-message', 'style': 'margin:6px 0' }, notes) ]);
+			}).catch(function() {});
 		}).catch(function(e) {
 			errBox.textContent = '';
 			errBox.appendChild(self.errorBox(_('保存失败：%s').format(e.message), self.backendErrorHint(e.message)));
@@ -676,7 +809,11 @@ return view.extend({
 				rows.push(E('tr', {}, [
 					E('td', {}, [ E('code', {}, (e.disabled ? '# ' : '') + e.key) ]),
 					E('td', {}, [ E('code', {}, e.value) ]),
-					E('td', {}, [ E('code', {}, (e.disabled || e.current == null) ? '—' : e.current) ]),
+					E('td', {}, [ E('code', {
+						/* value differs from kernel state: likely overridden by a
+						 * later config file (or write failed) -> highlight it */
+						'style': (!e.disabled && e.current != null && e.current != e.value) ? 'color:#a35a00;font-weight:600' : ''
+					}, (e.disabled || e.current == null) ? '—' : e.current) ]),
 					E('td', { 'style': 'white-space:nowrap' }, ops)
 				]));
 			}
@@ -812,6 +949,139 @@ return view.extend({
 		this.fileEditing = null;
 		this.refreshSourceChips();
 		this.renderFilePanel();
+	},
+
+	/* ---------- duplicate-key detection & cleanup ---------- */
+
+	showDupCheck: function() {
+		var self = this;
+
+		this.dupBox.style.display = '';
+		dom.content(this.dupBox, [
+			E('h3', { 'style': 'text-align:center' }, _('同名参数检测')),
+			E('p', { 'style': 'color:#777;text-align:center' }, _('扫描中…'))
+		]);
+
+		if (this.dupBox.scrollIntoView)
+			this.dupBox.scrollIntoView({ block: 'start' });
+
+		callDupCheck('').then(function(res) {
+			self.renderDupResults((res != null && res.dups != null) ? res.dups : []);
+		}).catch(function(e) {
+			dom.content(self.dupBox, [
+				E('h3', { 'style': 'text-align:center' }, _('同名参数检测')),
+				self.errorBox(_('扫描失败：%s').format(e.message), self.backendErrorHint(e.message))
+			]);
+		});
+	},
+
+	hideDupCheck: function() {
+		this.dupBox.style.display = 'none';
+		dom.content(this.dupBox, []);
+	},
+
+	renderDupResults: function(dups) {
+		var self = this;
+		var rows = [];
+		var customPath = '/etc/sysctl.d/99-luci-sysctl.conf';
+		var collapseBtn = E('div', { 'style': 'text-align:center;margin-top:8px' }, [
+			E('button', { 'class': 'btn', 'click': ui.createHandlerFn(self, 'hideDupCheck') }, _('收起'))
+		]);
+
+		if (dups.length == 0) {
+			dom.content(this.dupBox, [
+				E('h3', { 'style': 'text-align:center' }, _('同名参数检测')),
+				E('p', { 'style': 'text-align:center;color:#777;padding:8px' },
+					_('未发现在多个文件中重复定义的参数。')),
+				collapseBtn
+			]);
+			return;
+		}
+
+		for (var i = 0; i < dups.length; i++) {
+			var d = dups[i];
+			var entRows = [];
+			var finalEntry = null;
+
+			for (var j = 0; j < d.entries.length; j++) {
+				var e = d.entries[j];
+
+				if (!e.disabled)
+					finalEntry = e;
+
+				entRows.push(E('div', {
+					'style': 'display:flex;align-items:center;justify-content:center;gap:8px;margin:3px 0'
+				}, [
+					E('code', {}, e.path.replace('/etc/', '')),
+					E('span', { 'style': 'color:#999' }, '='),
+					E('code', {}, e.value),
+					e.disabled
+						? badge(_('已禁用'), 'off')
+						: E('span', { 'style': 'color:#18794e;font-size:12px' }, _('生效来源')),
+					(e.path != customPath)
+						? E('button', {
+							'class': 'cbi-button cbi-button-remove',
+							'title': _('从该文件删除此条目'),
+							'click': ui.createHandlerFn(self, 'dupDeleteEntry', e, d.key)
+						}, _('删除'))
+						: E('span', { 'style': 'color:#34618e;font-size:12px' }, _('自定义'))
+				]));
+			}
+
+			/* files order == application order; compare against custom conf */
+			var files = (this.statusData != null && this.statusData.files != null) ? this.statusData.files : [];
+			var paths = [];
+
+			for (var k = 0; k < files.length; k++)
+				paths.push(files[k].path);
+
+			var customIdx = paths.indexOf(customPath);
+			var shadowed = (finalEntry != null && customIdx >= 0 && paths.indexOf(finalEntry.path) > customIdx);
+			var warnText = (shadowed && finalEntry != null)
+				? _('生效来源（%s）加载在自定义配置之后：“添加参数”里设置该参数不会生效，请直接编辑该文件或删除其同名条目。').format(finalEntry.path.replace('/etc/', ''))
+				: _('自定义配置加载顺序靠后，“添加参数”设置该参数时会覆盖以上取值。');
+
+			rows.push(E('tr', {}, [
+				E('td', {}, [ E('code', {}, d.key) ]),
+				E('td', {}, E('div', {}, entRows)),
+				E('td', { 'style': 'max-width:300px' }, E('div', {
+					'style': 'color:' + (shadowed ? '#b3261e' : '#666')
+				}, warnText))
+			]));
+		}
+
+		dom.content(this.dupBox, [
+			E('h3', { 'style': 'text-align:center' }, _('同名参数检测')),
+			E('p', { 'style': 'color:#666;margin:4px 0;text-align:center' },
+				_('以下参数在多个配置文件中重复定义，按应用顺序以最后一个为准：')),
+			E('div', { 'class': 'lsc-tablewrap' }, E('table', { 'class': 'lsc-table' }, [
+				E('thead', {}, E('tr', {}, [
+					E('th', {}, _('参数名')),
+					E('th', {}, _('各文件定义（按应用顺序）')),
+					E('th', {}, _('说明'))
+				])),
+				E('tbody', rows)
+			])),
+			collapseBtn
+		]);
+	},
+
+	dupDeleteEntry: function(e, key) {
+		var self = this;
+
+		return callFileDelete(e.path, key).then(function(res) {
+			if (res == null || res.code != 0) {
+				ui.addNotification(null,
+					E('p', {}, _('删除失败：%s').format((res != null && res.error) ? res.error : _('未知错误'))),
+					'error');
+				return;
+			}
+
+			self.reloadList();
+			self.showDupCheck();
+		}).catch(function(err) {
+			ui.addNotification(null, E('p', {}, _('删除失败：%s').format(err.message)), 'error');
+		});
 	},
 
 	/* ---------- section 2: online preset ---------- */

--- a/applications/luci-app-sysctl/root/usr/share/rpcd/acl.d/luci-app-sysctl.json
+++ b/applications/luci-app-sysctl/root/usr/share/rpcd/acl.d/luci-app-sysctl.json
@@ -11,8 +11,9 @@
 					"preset_status",
 					"preset_fetch",
 					"preset_check",
-					"file_view",
-					"preset_list"
+				"file_view",
+				"preset_list",
+				"dup_check"
 				]
 			}
 		},

--- a/applications/luci-app-sysctl/root/usr/share/rpcd/ucode/luci.sysctl
+++ b/applications/luci-app-sysctl/root/usr/share/rpcd/ucode/luci.sysctl
@@ -791,8 +791,37 @@ const methods = {
 
 				out = strip_echo((out == null) ? '' : trim(out));
 
-				if (rc != 0 || length(out) > 0)
-					push(errors, { file: confs[i], code: rc, output: out });
+				/* busybox `sysctl -e -p` echoes every line and silently
+				 * swallows write failures -> echo alone proves nothing.
+				 * Read back each enabled entry from /proc/sys instead:
+				 * anything that differs was NOT accepted by the kernel. */
+				let not_applied = [];
+				let entries = parse_conf(confs[i]);
+
+				for (let j = 0; j < length(entries); j++) {
+					if (entries[j].disabled)
+						continue;
+
+					let cur = read_current(entries[j].key);
+
+					if (cur == null)
+						continue;   // key unknown to this kernel, -e skips it by design
+
+					if (cur != entries[j].value)
+						push(not_applied, {
+							key: entries[j].key,
+							value: entries[j].value,
+							current: cur
+						});
+				}
+
+				if (rc != 0 || length(out) > 0 || length(not_applied) > 0)
+					push(errors, {
+						file: confs[i],
+						code: rc,
+						output: out,
+						not_applied: not_applied
+					});
 			}
 
 			return { code: 0, errors: errors };

--- a/applications/luci-app-sysctl/root/usr/share/rpcd/ucode/luci.sysctl
+++ b/applications/luci-app-sysctl/root/usr/share/rpcd/ucode/luci.sysctl
@@ -549,6 +549,32 @@ function file_delete_key(path, key) {
 	return { code: 0, removed: removed };
 }
 
+// Strip the normal "key = value" echo lines that sysctl -p prints to stdout
+// for every successfully applied entry. What remains (if anything) is a
+// genuine error message like "sysctl: permission denied on key '...'".
+// NOTE: ucode regex has no non-capturing groups; plain pattern is fine here.
+function strip_echo(out) {
+	if (out == null || length(out) == 0)
+		return '';
+
+	let lines = split(out, '\n');
+	let rest = [];
+
+	for (let i = 0; i < length(lines); i++) {
+		let t = trim(lines[i]);
+
+		if (t == null || length(t) == 0)
+			continue;
+
+		if (match(t, /^[A-Za-z0-9_][A-Za-z0-9_.\/-]*[ \t]*=[ \t]*\S/) != null)
+			continue;
+
+		push(rest, t);
+	}
+
+	return join('\n', rest);
+}
+
 const methods = {
 	status: {
 		args: {},
@@ -763,7 +789,7 @@ const methods = {
 				let out = (p != null) ? p.read('all') : null;
 				let rc = (p != null) ? p.close() : -1;
 
-				out = (out == null) ? '' : trim(out);
+				out = strip_echo((out == null) ? '' : trim(out));
 
 				if (rc != 0 || length(out) > 0)
 					push(errors, { file: confs[i], code: rc, output: out });
@@ -1011,6 +1037,57 @@ const methods = {
 				return { code: 1, error: 'Invalid key' };
 
 			return file_delete_key(p, key);
+		}
+	},
+
+	// Locate a sysctl key across ALL config sources, in application order.
+	// Without args: return only keys defined in >= 2 files (duplicate map).
+	// With args.key: return that key's definitions even if defined once
+	// (used by the add/edit form to warn about shadowing overrides).
+	// Entries are ordered by file load order -> the LAST enabled entry wins.
+	dup_check: {
+		args: { key: '' },
+		call: function(request) {
+			let a = (request.args != null) ? request.args : {};
+			let want = trim(a.key);
+			let confs = collect_confs();
+			let by_key = {};
+			let order = [];
+
+			for (let i = 0; i < length(confs); i++) {
+				let path = confs[i];
+				let entries = parse_conf(path);
+
+				for (let j = 0; j < length(entries); j++) {
+					let k = entries[j].key;
+
+					if (want != null && length(want) > 0 && k != want)
+						continue;
+
+					if (by_key[k] == null) {
+						by_key[k] = [];
+						push(order, k);
+					}
+
+					push(by_key[k], {
+						path: path,
+						value: entries[j].value,
+						disabled: entries[j].disabled
+					});
+				}
+			}
+
+			let min_defs = (want != null && length(want) > 0) ? 1 : 2;
+			let dups = [];
+
+			for (let i = 0; i < length(order); i++) {
+				let k = order[i];
+
+				if (length(by_key[k]) >= min_defs)
+					push(dups, { key: k, entries: by_key[k] });
+			}
+
+			return { code: 0, dups: dups };
 		}
 	}
 };


### PR DESCRIPTION
## FAQ

**Q: 页面提示"权限被拒绝 / Not found"？**
rpcd 未注册 `luci.sysctl` 对象或 ACL 未生效：`/etc/init.d/rpcd restart` 后刷新页面。确认 `rpcd-mod-ucode` 已安装：`opkg list-installed | grep rpcd-mod-ucode`。

**Q: 在线预设获取失败？**
1. 直连 GitHub 不可达时，在"镜像前缀"填入加速前缀（如 `https://gh-proxy.org/`），最终地址为 前缀 + 原始 URL；
2. 建议直接使用 `raw.githubusercontent.com` 地址，粘贴 `github.com/.../blob/...` 页面地址会自动转换；
3. 预设源路由器需可解析 DNS 并出网，可先在 SSH 里验证：`curl -fsSL <镜像前缀+URL> | head`；
4. 下载器依次尝试 curl / wget / uclient-fetch，三者都失败时提示 Download failed。

**Q: 保存提示"参数在当前内核中不存在"？**
该 key 在 `/proc/sys` 下无对应节点，多半是功能未编译进内核或模块未加载。配置仍会保存，模块加载后下次开机生效。

**Q: 写入提示只读（readonly）？**
部分参数（如部分 `kernel.*`）在运行时不可写，只能保存配置，重启后由系统应用。

**Q: 修改后重启会丢吗？**
不会。所有修改持久化在 `/etc/sysctl.d/99-luci-sysctl.conf`，该文件已声明为 conffile，系统升级也会保留。

**Q: 和手动编辑 /etc/sysctl.conf 冲突吗？**
不冲突。`/etc/sysctl.conf` 也可直接点击配置源标签在页面编辑，编辑结果与手动改文件完全一致；自定义参数仍推荐放在 `99-luci-sysctl.conf`（文件名靠后、优先级最高）。

**Q: 删除某文件里最后一条参数时提示"删除失败"？**
该问题在 v1.5.3 已修复（旧版误把"成功写入空文件"当失败，实际文件已删净）。如仍遇到请确认已安装 v1.5.3 及以上版本。

**Q: 为什么总览表里看不到 /etc/sysctl.conf 的参数？**
设计如此（v1.5.4 起）：主配置参数统一通过点击 `sysctl.conf` 标签查看/编辑，避免与配置源列表重复展示。

**Q: 明明改了参数、应用配置也成功，为什么当前值没变？**
大概率同名参数被多个文件定义，你的值被后面加载的文件覆盖了（文件名字典序越靠后优先级越高，如 `99-conntrack.conf` 会覆盖 `99-luci-sysctl.conf`）。点击 **检测重复** 可看到完整的定义链与生效来源，按提示删除多余定义或直接编辑生效文件。

## 更新日志

### v1.7.4
- 修复标准 OpenWrt 24.10 主题下操作按钮行（添加参数/应用配置/检测重复/刷新）不居中：新版主题按钮行为 flex 布局（justify-content: flex-end），旧修复仅覆盖 float+text-align 方式；现两种布局方式都强制居中，并统一按钮间距。纯前端改动

### v1.7.3
- 修复"当前值"不刷新：已打开的文件内容面板在点击 **应用配置** / **刷新** 后不重新读取内核值，导致刚应用的参数看起来"没生效"（实际已生效，如状态页连接数上限已更新而插件页仍显示旧值）；现应用/刷新后自动重读当前值
- 纯前端改动，装完刷新即可

### v1.7.2
- 修复"应用配置"假成功：BusyBox `sysctl -e -p` 会回显所有行并静默吞掉写入失败，v1.6.0 清理回显后失败痕迹完全消失、误显"全部成功"；现改为**应用后逐参数读回内核值校验**，内核未接受的参数（配置值 ≠ 内核当前值）在结果中明确列出"写入 X，内核当前 Y"，不再依赖 sysctl 输出判断成败
- 需重启 rpcd 生效（后端 apply 校验逻辑有改动）

### v1.7.1
- 修复"添加参数"按钮无法打开编辑表单的问题（v1.0 起潜伏：按钮传空参数时表单渲染被跳过；此前用户均经浏览区/主配置行入口添加，故未暴露）。纯前端改动，装完刷新即可

### v1.7.0
- 新增**同名参数检测**：操作按钮行新增“检测重复”，一键扫描所有配置源，列出在多个文件中重复定义的参数、各文件取值（按应用顺序标出“生效来源”），并提供一键从指定文件删除该条目
- 添加/编辑参数时实时提醒：输入参数名后自动检查该参数是否在其他文件中也有定义；若存在加载顺序在自定义配置之后的定义（会覆盖你设置的值），以红色警示并给出处理建议
- 保存成功提示中同步追加重复定义提示
- 需重启 rpcd 生效（后端新增 dup_check 方法、ACL 更新）

### v1.6.0
- 修复"应用配置"误报：`sysctl -p` 对成功应用的参数会回显 `key = value` 行，旧版把"有输出"一律当报错弹出橙色警告框；现自动剔除正常回显，仅真正的错误（如 `sysctl: permission denied ...`）才提示
- 文件内容表新增"未生效"提示：当前值与配置值不一致时（通常被后加载的配置源覆盖，或写入被内核拒绝），当前值以橙色加粗显示
- 需重启 rpcd 生效（后端 apply 逻辑有改动）