### PR TITLE
fix(luci-base): 修复 dnsmasq 编译选项正则匹配缺陷导致前端隐藏 DHCP-Options 的问题

### DIFF
--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -298,7 +298,7 @@ const methods = {
 			let fd = popen('dnsmasq --version 2>/dev/null');
 
 			if (fd) {
-				const m = match(fd.read('all'), /^Compile time options: (.+)$/s);
+				const m = match(fd.read('all'), /Compile time options: ([^\n]+)/);
 
 				for (let opt in split(m?.[1], ' ')) {
 					let f = replace(opt, 'no-', '', 1);


### PR DESCRIPTION
### 问题分析
在 `modules/luci-base/root/usr/share/rpcd/ucode/luci` 中探测 dnsmasq 功能时，原正则采用了： `match(fd.read('all'), /^Compile time options: (.+)$/s)`

由于 `dnsmasq --version` 的第一行输出是版权与版本声明（例如 `Dnsmasq version 2.90...`），`Compile time options:` 实际在第二行。原正则中的 `^` 锚定在全文开头，导致 `m` 永远匹配失败（返回 `null`）。 这导致 `result.dnsmasq` 未能生成，前端 `L.hasSystemFeature('dnsmasq')` 恒为 `false`，使得 Web 界面【网络 -> 接口 -> LAN -> DHCP 服务器】中的【DHCP 选项】(DHCP-Options)、【强制】等关键输入框被错误隐藏。

### 修复方案
移除开头的全文锚定 `^`，使用 `/Compile time options: ([^\n]+)/` 捕获该行选项，确保 `result.dnsmasq` 正常注入，恢复 Web 界面 DHCP 选项的正常渲染与配置。

<!--

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/immortalwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. immortalwrt/immortalwrt
- each commit subject line starts with '<package name>: title'
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [ ] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [ ] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [ ] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [ ] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [ ] Description: (describe the changes proposed in this PR)
